### PR TITLE
feat: graceful shutdown (Issue #30) — close all 12 gaps

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,10 +17,6 @@
 .DS_Store
 Thumbs.db
 
-# Environment files (contain secrets)
-.env
-.env.*
-*.env.local
 
 # Logs
 *.log
@@ -33,9 +29,11 @@ Thumbs.db
 # Documentation build
 AUDIT_REPORT_NIM_V4.md
 /docs/
-.*
-!.gitignore
-!.env.example
+# Dotfiles (specific — avoid blanket .* which blocks .github/, .cargo/, etc.)
+.env
+.env.*
+*.env.local
+.nexus-ai-gateway.env
 
 # Temporary files
 /tmp/

--- a/.gitignore
+++ b/.gitignore
@@ -31,8 +31,11 @@ Thumbs.db
 /.coverage/
 
 # Documentation build
+AUDIT_REPORT_NIM_V4.md
 /docs/
-
+.*
+!.gitignore
+!.env.example
 
 # Temporary files
 /tmp/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,4 @@
-# CLAUDE.md
-This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+# CLAUDE.md This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
 
 ## Development Commands
 
@@ -9,22 +8,31 @@ cargo build --release          # Production build (~7 MB binary)
 cargo build                    # Debug build
 
 # Testing
-cargo test                     # Run all tests (95 unit + 4 integration + 3 version sync)
+cargo test                     # Run all tests
 cargo test tokenizer_test      # Run specific test module by path
 cargo test -- --nocapture      # Show println! output
+cargo test --test integration  # Integration tests only (wiremock)
 
 # Linting & Formatting
 cargo fmt --check              # Check formatting
-cargo clippy -- -D warnings    # Lint (warnings as errors)
+cargo clippy -- -D warnings   # Lint (warnings as errors)
 
 # Security Audit
 cargo audit                    # Check for CVEs in dependencies
 
-# Task Runner (via Taskfile.yaml)
+# Task Runner (via Taskfile.yaml — preferred)
+task check                     # Full check: fmt + lint + test
 task test                      # Run all tests
 task version-check             # Verify VERSION/Cargo.toml/lib.rs sync
-task check                     # Run fmt-check + lint + test
-task install                   # Build and install to ~/.cargo/bin
+task install                   # Build + install to ~/.cargo/bin
+task sync-binary               # Install to ~/.cargo/bin AND ~/.local/bin with md5 verify
+task setup                     # Full project setup (build, hooks, service)
+task service-status            # Check systemd service status
+task service-logs              # Follow service logs
+task bump-patch                # Bump PATCH version
+task bump-minor                # Bump MINOR version
+task auto-version              # Auto-detect bump from conventional commits
+task full-release              # One-command release (auto-bump + commit + tag + push)
 ```
 
 ## Architecture
@@ -33,29 +41,29 @@ task install                   # Build and install to ~/.cargo/bin
 
 ```
 Claude Code → POST /v1/messages
-                    ↓
-              proxy::proxy_handler (src/proxy/mod.rs)
-                    ↓
-              ├─ validate_request (pre-flight checks)
-              ├─ transform::anthropic_to_openai (bidirectional conversion)
-              ├─ discovery::get_context_limit (caches model capabilities)
-              ├─ tokenizer::estimate_from_openai_request (tiktoken pre-check)
-              └─ concurrency::ModelSemaphores (per-model rate limiting)
-                    ↓
-         streaming::handle_streaming OR non_streaming::handle_non_streaming
-                    ↓
-              ├─ retry::execute_with_retry (3-layer classification)
-              ├─ classify::classify_error (L1/L2/L3 error detection)
-              └─ circuit_breaker::CircuitBreaker (optional)
-                    ↓
-              Upstream OpenAI-compatible API
-                    ↓
-              SSE Stream → transform back to Anthropic format
+↓
+proxy::proxy_handler (src/proxy/mod.rs)
+↓
+├─ validate_request (pre-flight checks)
+├─ transform::anthropic_to_openai (bidirectional conversion)
+├─ discovery::get_context_limit (caches model capabilities)
+├─ tokenizer::estimate_from_openai_request (tiktoken pre-check)
+└─ concurrency::ModelSemaphores (per-model rate limiting)
+↓
+streaming::handle_streaming OR non_streaming::handle_non_streaming
+↓
+├─ retry::execute_with_retry (3-layer classification)
+├─ classify::classify_error (L1=status, L2=pattern, L3=structural)
+└─ circuit_breaker::CircuitBreaker (optional)
+↓
+Upstream OpenAI-compatible API
+↓
+SSE Stream → transform back to Anthropic format
 ```
 
 ### Module Organization
 
-The `src/proxy/` directory contains 10 modules (~2382 LOC total) decomposed from the original monolithic proxy.rs:
+**Proxy layer** — `src/proxy/` (~2382 LOC total, decomposed from monolithic proxy.rs):
 
 | Module | Purpose |
 |--------|---------|
@@ -63,21 +71,47 @@ The `src/proxy/` directory contains 10 modules (~2382 LOC total) decomposed from
 | `streaming.rs` | SSE streaming with anthropic.keep-alive |
 | `non_streaming.rs` | Synchronous response handling |
 | `retry.rs` | 3-layer retry with exponential backoff |
-| `classify.rs` | Error classification (L1=status, L2=pattern, L3=structural) |
-| `rate_limit.rs` | Rate limit detection (L1/L2/L3) |
+| `classify.rs` | Error classification (L1/L2/L3) |
+| `rate_limit.rs` | Rate limit detection |
 | `concurrency.rs` | Per-model semaphores, circuit breaker |
 | `discovery.rs` | Model capability probing with caching |
 | `overflow_tracker.rs` | Context window overflow tracking |
 | `error_types.rs` | Upstream error structures |
+
+**Models layer** — `src/models/` (API type definitions):
+
+| Module | Purpose |
+|--------|---------|
+| `anthropic.rs` | Anthropic request/response types, SSE events, Usage with cache token fields |
+| `openai.rs` | OpenAI-compatible request/response types |
+| `mod.rs` | Re-exports |
+
+**Other modules** — `src/` root:
+
+| Module | Purpose |
+|--------|---------|
+| `transform.rs` | Bidirectional Anthropic↔OpenAI conversion, `clean_schema`, thinking sanitization |
+| `config.rs` | Config loading from env/.env, hot-reload, `SharedConfig = Arc<ArcSwap<Config>>` |
+| `circuit_breaker.rs` | Circuit breaker (Closed/Open/HalfOpen states) — currently default-off |
+| `prompt_cache.rs` | SHA-256 content hashing, TTL+LRU proxy-side cache (for NIM KV-cache reuse) |
+| `tokenizer.rs` | Token estimation via tiktoken cl100k_base |
+| `web_fetch.rs` | WebFetch tool interception — fetches URLs locally, strips HTML |
+| `scan.rs` | NIM model discovery via `/v1/models` endpoint |
+| `setup.rs` | First-time setup wizard |
+| `str_utils.rs` | UTF-8 safe string truncation (prevents panic on multi-byte chars) |
+| `watcher.rs` | File watcher for .env hot-reload |
+| `cli.rs` | CLI argument parsing (clap) |
 
 ### Key Dependencies
 
 - `axum 0.7` — HTTP server + middleware
 - `tokio 1.42` — Async runtime
 - `reqwest 0.12` — HTTP client (pool_max_idle_per_host: 50, tcp_keepalive: 60s)
-- `arc-swap 1.x` — Lock-free config reads via SharedConfig = Arc<ArcSwap<Config>>
+- `arc-swap 1.x` — Lock-free config reads via `SharedConfig = Arc<ArcSwap<Config>>`
 - `tiktoken-rs 0.11` — Token estimation using cl100k_base
 - `metrics-exporter-prometheus 0.18` — Prometheus metrics endpoint
+- `clap 4` — CLI argument parsing
+- `dotenvy` — .env file loading
 
 ## Critical Design Conventions
 
@@ -107,19 +141,39 @@ These behaviors are intentional and should not be changed:
 
 9. **No Anthropic API key validation BY DESIGN** — Any non-empty key is accepted. Gateway validates upstream credentials only.
 
+## Key Environment Variables
+
+| Variable | Default | Purpose |
+|----------|---------|---------|
+| `UPSTREAM_BASE_URL` | (required) | Upstream API endpoint URL |
+| `UPSTREAM_API_KEY` | (required) | API key for upstream service |
+| `NEXUS_UPSTREAM_TYPE` | `nim` | Upstream type: `anthropic`, `nim`, `openai`, `openrouter` |
+| `PORT` | `8315` | Server port |
+| `DEBUG` | `false` | Enable debug logging |
+| `VERBOSE` | `false` | Full request/response logging |
+| `CC_CONTEXT_WINDOW` | `200000` | Context window size for auto-compact calibration |
+| `CC_OVERFLOW_THRESHOLD_PCT` | `80` | Context overflow threshold (50-95%) |
+| `PROBE_CACHE_TTL_SECS` | `3600` | Model capability probe cache TTL |
+| `DISABLE_PROBING` | `false` | Disable runtime model probing |
+| `MODEL_LIMIT_OVERRIDES` | (none) | Override model context limits: `model_id:tokens` |
+| `CORS_ALLOWED_ORIGINS` | `*` | Comma-separated allowed CORS origins |
+| `NIM_PROMPT_CACHE_ENABLED` | `false` | Enable proxy-side prompt cache for NIM |
+
+Model mapping: `MODEL_MAP_<claude_id_with_underscores>=<upstream>:<model>` (hyphens → underscores in model IDs)
+
 ## Testing Strategy
 
-- **Unit tests**: In `#[cfg(test)]` modules within source files (95 tests)
-- **Integration tests**: `tests/integration_test.rs` using wiremock (4 tests)
-- **Version sync tests**: `tests/version_sync.rs` validates 3-file sync (3 tests)
+- **Unit tests**: In `#[cfg(test)]` modules within source files
+- **Integration tests**: `tests/integration_test.rs` using wiremock
+- **Version sync tests**: `tests/version_sync.rs` validates 3-file sync
 
 Run specific module tests:
 ```bash
-cargo test tokenizer_test      # src/tokenizer_test.rs
-cargo test validation_tests    # src/proxy/mod.rs::validation_tests
-cargo test threshold_tests     # src/proxy/mod.rs::threshold_tests
-cargo test error_test          # src/error_test.rs
-cargo test --test integration  # tests/integration_test.rs only
+cargo test tokenizer_test        # src/tokenizer_test.rs
+cargo test validation_tests      # src/proxy/mod.rs::validation_tests
+cargo test threshold_tests       # src/proxy/mod.rs::threshold_tests
+cargo test error_test            # src/error_test.rs
+cargo test --test integration    # tests/integration_test.rs only
 ```
 
 ## Version Management
@@ -130,6 +184,18 @@ Three files must stay synchronized:
 - `src/lib.rs` — `pub const VERSION: &str = "X.Y.Z"`
 
 Run `task version-check` to verify. CI enforces this on every push.
+
+## Git Hooks & CI
+
+Hooks are in `scripts/hooks/` (portable, not in `.git/hooks/`):
+- **pre-commit**: `cargo fmt --check`
+- **commit-msg**: Conventional commits format validation
+- **pre-push**: Version sync + `cargo test` + `cargo clippy` + `cargo audit` (main branch only)
+- **post-merge**: Auto-rebuild + install + restart systemd service (main branch only, version change detected)
+
+Setup: `task setup-hooks` or `bash scripts/setup-hooks.sh`
+
+CI: `.github/workflows/ci.yml` → `.github/workflows/auto-version.yml` (auto-bumps version on conventional commits, creates GitHub Release with binary)
 
 ## API Endpoints
 
@@ -143,3 +209,7 @@ Run `task version-check` to verify. CI enforces this on every push.
 ## Port Convention
 
 Default port **8315**: N(78) + E(69) + U(85) + S(83) = 315 → 8315
+
+## Documentation Repo
+
+Documentation, audit reports, and issue tracking are in a **separate private repo**: `enerBydev/nexus-ai-gateway_docs` (auto-synced via `nexus-docs-sync.sh` — auto-commit on changes, daily push at 00:00).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -158,6 +158,7 @@ These behaviors are intentional and should not be changed:
 | `MODEL_LIMIT_OVERRIDES` | (none) | Override model context limits: `model_id:tokens` |
 | `CORS_ALLOWED_ORIGINS` | `*` | Comma-separated allowed CORS origins |
 | `NIM_PROMPT_CACHE_ENABLED` | `false` | Enable proxy-side prompt cache for NIM |
+| `DRAIN_TIMEOUT_SECS` | `30` | Max graceful drain duration before forced shutdown |
 
 Model mapping: `MODEL_MAP_<claude_id_with_underscores>=<upstream>:<model>` (hyphens → underscores in model IDs)
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -204,7 +204,7 @@ CI: `.github/workflows/ci.yml` → `.github/workflows/auto-version.yml` (auto-bu
 |----------|--------|-------------|
 | `/v1/messages` | POST | Main proxy endpoint (Anthropic Messages API) |
 | `/v1/messages/count_tokens` | POST | Token count estimation |
-| `/health` | GET | Health check (returns `OK`) |
+| `/health` | GET | Health check (`200 OK` normal, `503` during drain) |
 | `/metrics` | GET | Prometheus metrics |
 
 ## Port Convention

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1339,6 +1339,7 @@ dependencies = [
  "tiktoken-rs",
  "tokio",
  "tokio-stream",
+ "tokio-util",
  "tower",
  "tower-http",
  "tracing",
@@ -2204,6 +2205,7 @@ dependencies = [
  "bytes",
  "futures-core",
  "futures-sink",
+ "futures-util",
  "pin-project-lite",
  "tokio",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,7 @@ serde_json = "1.0"
 # Async utilities
 futures = "0.3"
 tokio-stream = "0.1"
+tokio-util = { version = "0.7", features = ["rt"] }
 
 # Observability
 tracing = "0.1"

--- a/scripts/logrotate-nexus.conf
+++ b/scripts/logrotate-nexus.conf
@@ -1,0 +1,11 @@
+/tmp/nexus-ai-gateway.log {
+    daily
+    rotate 7
+    compress
+    delaycompress
+    missingok
+    notifempty
+    copytruncate
+    size 50M
+    maxsize 200M
+}

--- a/scripts/nexus-ai-gateway.service
+++ b/scripts/nexus-ai-gateway.service
@@ -13,17 +13,24 @@ RestartSec=3
 # Prevent restart loops: 5 failures in 60s = stop trying
 StartLimitIntervalSec=60
 StartLimitBurst=5
+# Graceful shutdown: only kill main process, let it drain connections
+KillMode=process
+# Aligned with DRAIN_TIMEOUT_SECS=30 + 15s margin
+TimeoutStopSec=45
+# No SIGKILL — let the process exit cleanly after draining
+SendSIGKILL=no
 
 # Environment: load from .env file
 EnvironmentFile=-%h/.nexus-ai-gateway.env
 
-# Logging — dual: journald (rotated) + file (truncated on restart)
+# Logging — dual: journald (rotated) + file (use logrotate for rotation)
 SyslogIdentifier=nexus-ai-gateway
 StandardOutput=append:/tmp/nexus-ai-gateway.log
 StandardError=append:/tmp/nexus-ai-gateway.log
 
-# Truncate log file on restart to prevent unbounded growth
-ExecStartPre=/usr/bin/truncate -s 0 /tmp/nexus-ai-gateway.log
+# Log rotation: install with
+#   sudo cp scripts/logrotate-nexus.conf /etc/logrotate.d/nexus-ai-gateway
+# For user-level: add to personal crontab or use logrotate --state
 
 # Hardening
 NoNewPrivileges=true

--- a/scripts/smoke-test-graceful-shutdown.sh
+++ b/scripts/smoke-test-graceful-shutdown.sh
@@ -38,15 +38,21 @@ NC='\033[0m' # No Color
 
 # ─── State ───────────────────────────────────────────────────────────────────
 PID=""
+CARGO_PID=""
 PASSED=0
 FAILED=0
 
-# ─── Cleanup ─────────────────────────────────────────────────────────────────
 cleanup() {
     if [[ -n "${PID}" ]] && kill -0 "${PID}" 2>/dev/null; then
-        echo -e "${YELLOW}[CLEANUP]${NC} Killing leftover process ${PID}"
+        echo -e "${YELLOW}[CLEANUP]${NC} Killing leftover gateway process ${PID}"
         kill -9 "${PID}" 2>/dev/null || true
         wait "${PID}" 2>/dev/null || true
+    fi
+    # CR3: Also clean up the cargo launcher process if it is still running
+    if [[ -n "${CARGO_PID:-}" ]] && kill -0 "${CARGO_PID}" 2>/dev/null; then
+        echo -e "${YELLOW}[CLEANUP]${NC} Killing leftover cargo launcher ${CARGO_PID}"
+        kill -9 "${CARGO_PID}" 2>/dev/null || true
+        wait "${CARGO_PID}" 2>/dev/null || true
     fi
 }
 trap cleanup EXIT
@@ -92,12 +98,16 @@ echo ""
 echo -e "${YELLOW}[TEST 1]${NC} Starting NEXUS-AI-Gateway..."
 
 if [[ "${BINARY}" == "cargo-run" ]]; then
+    # CR3: cargo run spawns a child process — $! gives cargo PID, not gateway PID.
+    # We launch cargo in background, then resolve the real gateway PID after startup.
     PORT="${PORT}" cargo run 2>/dev/null &
+    CARGO_PID=$!
+    info "Cargo launcher PID: ${CARGO_PID}"
 else
     PORT="${PORT}" "${BINARY}" 2>/dev/null &
+    PID=$!
+    info "Started with PID ${PID}"
 fi
-PID=$!
-info "Started with PID ${PID}"
 
 # Wait for server to become healthy
 elapsed=0
@@ -115,6 +125,21 @@ if [[ "${status}" == "200" ]]; then
 else
     fail "Server did not become healthy within ${STARTUP_TIMEOUT}s (last status: ${status})"
     exit 1
+fi
+# CR3: When using cargo-run, resolve the actual gateway PID from the listening port.
+# $! gives cargo's PID, not the gateway process. We find the real PID via ss/lsof.
+if [[ "${BINARY}" == "cargo-run" ]]; then
+    GATEWAY_PID=$(ss -tlnp "sport = :${PORT}" 2>/dev/null | grep -oP 'pid=\K[0-9]+' | head -1)
+    if [[ -z "${GATEWAY_PID}" ]]; then
+        GATEWAY_PID=$(lsof -ti :${PORT} 2>/dev/null | head -1)
+    fi
+    if [[ -n "${GATEWAY_PID}" ]]; then
+        PID="${GATEWAY_PID}"
+        info "Resolved gateway PID: ${PID} (cargo launcher: ${CARGO_PID})"
+    else
+        warn "Could not resolve gateway PID — SIGTERM will target cargo launcher ${CARGO_PID}"
+        PID="${CARGO_PID}"
+    fi
 fi
 
 # ─── Test 2: Verify /health returns 200 during normal operation ─────────────

--- a/scripts/smoke-test-graceful-shutdown.sh
+++ b/scripts/smoke-test-graceful-shutdown.sh
@@ -1,0 +1,188 @@
+#!/usr/bin/env bash
+# smoke-test-graceful-shutdown.sh — Verify NEXUS-AI-Gateway graceful shutdown lifecycle
+#
+# Usage:
+#   ./scripts/smoke-test-graceful-shutdown.sh              # Default: cargo run on port 8315
+#   PORT=9999 ./scripts/smoke-test-graceful-shutdown.sh    # Custom port
+#   BINARY=~/.cargo/bin/nexus-ai-gateway ./scripts/...    # Use installed binary
+#   DRAIN_TIMEOUT_SECS=60 ./scripts/...                   # Custom drain timeout
+#
+# Prerequisites:
+#   - UPSTREAM_BASE_URL and UPSTREAM_API_KEY set in ~/.nexus-ai-gateway.env or environment
+#   - curl installed
+#   - cargo (if using default BINARY=cargo-run)
+#
+# What it tests:
+#   1. Server starts and /health returns 200
+#   2. SIGTERM triggers drain mode
+#   3. /health returns 503 during drain
+#   4. Process exits within DRAIN_TIMEOUT_SECS + margin
+#
+set -euo pipefail
+
+# ─── Configuration ───────────────────────────────────────────────────────────
+PORT="${PORT:-8315}"
+DRAIN_TIMEOUT_SECS="${DRAIN_TIMEOUT_SECS:-30}"
+BINARY="${BINARY:-cargo-run}"
+HEALTH_URL="http://127.0.0.1:${PORT}/health"
+MARGIN_SECS=15
+MAX_WAIT_SECS=$((DRAIN_TIMEOUT_SECS + MARGIN_SECS))
+STARTUP_TIMEOUT=10
+
+# ─── Colors ──────────────────────────────────────────────────────────────────
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+CYAN='\033[0;36m'
+NC='\033[0m' # No Color
+
+# ─── State ───────────────────────────────────────────────────────────────────
+PID=""
+PASSED=0
+FAILED=0
+
+# ─── Cleanup ─────────────────────────────────────────────────────────────────
+cleanup() {
+    if [[ -n "${PID}" ]] && kill -0 "${PID}" 2>/dev/null; then
+        echo -e "${YELLOW}[CLEANUP]${NC} Killing leftover process ${PID}"
+        kill -9 "${PID}" 2>/dev/null || true
+        wait "${PID}" 2>/dev/null || true
+    fi
+}
+trap cleanup EXIT
+
+# ─── Helpers ─────────────────────────────────────────────────────────────────
+pass() { PASSED=$((PASSED + 1)); echo -e "  ${GREEN}✅ PASS${NC}: $1"; }
+fail() { FAILED=$((FAILED + 1)); echo -e "  ${RED}❌ FAIL${NC}: $1"; }
+info() { echo -e "  ${CYAN}ℹ️${NC} $1"; }
+warn() { echo -e "  ${YELLOW}⚠️${NC} $1"; }
+
+http_status() {
+    curl -s -o /dev/null -w '%{http_code}' --max-time 5 "$1" 2>/dev/null || echo "000"
+}
+
+# ─── Load environment ────────────────────────────────────────────────────────
+ENV_FILE="${HOME}/.nexus-ai-gateway.env"
+if [[ -f "${ENV_FILE}" ]]; then
+    # shellcheck disable=SC1090
+    set -a; source "${ENV_FILE}"; set +a
+    info "Loaded environment from ${ENV_FILE}"
+else
+    warn "No .env file at ${ENV_FILE} — ensure UPSTREAM_BASE_URL and UPSTREAM_API_KEY are set"
+fi
+
+# ─── Verify prerequisites ───────────────────────────────────────────────────
+if ! command -v curl &>/dev/null; then
+    echo -e "${RED}ERROR${NC}: curl is required but not installed"
+    exit 1
+fi
+
+echo ""
+echo -e "${CYAN}═══════════════════════════════════════════════════════════════${NC}"
+echo -e "${CYAN}  NEXUS-AI-Gateway — Graceful Shutdown Smoke Test${NC}"
+echo -e "${CYAN}═══════════════════════════════════════════════════════════════${NC}"
+echo -e "  Port:              ${PORT}"
+echo -e "  Drain timeout:     ${DRAIN_TIMEOUT_SECS}s"
+echo -e "  Max wait:          ${MAX_WAIT_SECS}s"
+echo -e "  Binary:            ${BINARY}"
+echo -e "  Health URL:        ${HEALTH_URL}"
+echo ""
+
+# ─── Test 1: Start server ────────────────────────────────────────────────────
+echo -e "${YELLOW}[TEST 1]${NC} Starting NEXUS-AI-Gateway..."
+
+if [[ "${BINARY}" == "cargo-run" ]]; then
+    PORT="${PORT}" cargo run 2>/dev/null &
+else
+    PORT="${PORT}" "${BINARY}" 2>/dev/null &
+fi
+PID=$!
+info "Started with PID ${PID}"
+
+# Wait for server to become healthy
+elapsed=0
+while [[ ${elapsed} -lt ${STARTUP_TIMEOUT} ]]; do
+    status=$(http_status "${HEALTH_URL}")
+    if [[ "${status}" == "200" ]]; then
+        break
+    fi
+    sleep 1
+    elapsed=$((elapsed + 1))
+done
+
+if [[ "${status}" == "200" ]]; then
+    pass "Server started and /health returned 200 (${elapsed}s)"
+else
+    fail "Server did not become healthy within ${STARTUP_TIMEOUT}s (last status: ${status})"
+    exit 1
+fi
+
+# ─── Test 2: Verify /health returns 200 during normal operation ─────────────
+echo -e "${YELLOW}[TEST 2]${NC} Verifying /health returns 200 during normal operation..."
+status=$(http_status "${HEALTH_URL}")
+if [[ "${status}" == "200" ]]; then
+    pass "/health returned 200 during normal operation"
+else
+    fail "/health returned ${status} (expected 200)"
+fi
+
+# ─── Test 3: Send SIGTERM and verify drain mode ─────────────────────────────
+echo -e "${YELLOW}[TEST 3]${NC} Sending SIGTERM to PID ${PID}..."
+kill -TERM "${PID}" 2>/dev/null
+
+# Give the process a moment to set IS_DRAINING=true
+sleep 2
+
+status=$(http_status "${HEALTH_URL}")
+if [[ "${status}" == "503" ]]; then
+    pass "/health returned 503 during drain (IS_DRAINING working)"
+else
+    # Process may have already exited (fast drain) — that's also acceptable
+    if ! kill -0 "${PID}" 2>/dev/null; then
+        pass "Process exited quickly (no active connections to drain)"
+    else
+        fail "/health returned ${status} during drain (expected 503)"
+    fi
+fi
+
+# ─── Test 4: Verify process exits within timeout ────────────────────────────
+echo -e "${YELLOW}[TEST 4]${NC} Waiting for process to exit (max ${MAX_WAIT_SECS}s)..."
+
+elapsed=0
+while [[ ${elapsed} -lt ${MAX_WAIT_SECS} ]]; do
+    if ! kill -0 "${PID}" 2>/dev/null; then
+        break
+    fi
+    sleep 1
+    elapsed=$((elapsed + 1))
+done
+
+if ! kill -0 "${PID}" 2>/dev/null; then
+    if [[ ${elapsed} -le ${DRAIN_TIMEOUT_SECS} ]]; then
+        pass "Process exited within drain timeout (${elapsed}s <= ${DRAIN_TIMEOUT_SECS}s)"
+    else
+        pass "Process exited within max wait (${elapsed}s <= ${MAX_WAIT_SECS}s, exceeded drain timeout by $((elapsed - DRAIN_TIMEOUT_SECS))s)"
+    fi
+    wait "${PID}" 2>/dev/null || true
+    PID=""
+else
+    fail "Process did not exit within ${MAX_WAIT_SECS}s — killing"
+    kill -9 "${PID}" 2>/dev/null || true
+    wait "${PID}" 2>/dev/null || true
+    PID=""
+fi
+
+# ─── Summary ─────────────────────────────────────────────────────────────────
+echo ""
+echo -e "${CYAN}═══════════════════════════════════════════════════════════════${NC}"
+echo -e "${CYAN}  Results: ${GREEN}${PASSED} passed${NC}, ${RED}${FAILED} failed${NC}"
+echo -e "${CYAN}═══════════════════════════════════════════════════════════════${NC}"
+echo ""
+
+if [[ ${FAILED} -eq 0 ]]; then
+    echo -e "${GREEN}🎉 All smoke tests passed! Graceful shutdown is working correctly.${NC}"
+    exit 0
+else
+    echo -e "${RED}💥 Some tests failed. Review the output above.${NC}"
+    exit 1
+fi

--- a/src/main.rs
+++ b/src/main.rs
@@ -411,18 +411,22 @@ async fn async_main(cli: Cli) -> anyhow::Result<()> {
         std::env::var("DRAIN_TIMEOUT_SECS").ok().and_then(|v| v.parse().ok()).unwrap_or(30);
     tracing::info!("Drain timeout: {}s", drain_timeout_secs);
 
-    // CR4 fix: Drain timeout must only start AFTER the shutdown signal,
-    // not at boot time. We use a dedicated CancellationToken for the
-    // server's graceful shutdown, separate from SHUTDOWN_TOKEN (which
-    // cancels SSE streams). The flow is:
-    //   1. Server runs with graceful_shutdown triggered by server_shutdown_token
-    //   2. shutdown_signal() fires → sets IS_DRAINING, cancels SHUTDOWN_TOKEN
-    //   3. We then cancel server_shutdown_token → server stops accepting
-    //   4. Drain timeout starts → races against server completing
+    // CR4/CR8 fix: Server must be spawned immediately so it starts accepting
+    // connections. Drain timeout starts only AFTER the shutdown signal.
+    // We use a dedicated CancellationToken for the server's graceful shutdown,
+    // separate from SHUTDOWN_TOKEN (which cancels SSE streams). The flow is:
+    // 1. Server is spawned — begins serving immediately
+    // 2. shutdown_signal() fires → sets IS_DRAINING, cancels SHUTDOWN_TOKEN
+    // 3. We then cancel server_shutdown_token → server stops accepting
+    // 4. Drain timeout starts → races against server task completing
     let server_shutdown_token = tokio_util::sync::CancellationToken::new();
     let server_ct_for_graceful = server_shutdown_token.clone();
-    let server = axum::serve(listener, app).with_graceful_shutdown(async move {
-        server_ct_for_graceful.cancelled().await;
+    let server_handle = tokio::spawn(async move {
+        axum::serve(listener, app)
+            .with_graceful_shutdown(async move {
+                server_ct_for_graceful.cancelled().await;
+            })
+            .await
     });
 
     // Phase 1: Normal serving — wait for shutdown signal
@@ -432,14 +436,21 @@ async fn async_main(cli: Cli) -> anyhow::Result<()> {
     // Phase 2: Signal server to stop accepting new connections
     server_shutdown_token.cancel();
 
-    // Phase 3: Drain — race server completion against drain timeout
+    // Phase 3: Drain — race server task completion against drain timeout
     let drain_timeout = tokio::time::Duration::from_secs(drain_timeout_secs);
     tokio::select! {
-        result = server => {
-            if let Err(e) = result {
-                tracing::error!("Server error: {}", e);
+        result = server_handle => {
+            match result {
+                Ok(Ok(())) => {
+                    tracing::info!("✅ Shutdown complete: all connections drained before timeout");
+                }
+                Ok(Err(e)) => {
+                    tracing::error!("Server error: {}", e);
+                }
+                Err(e) => {
+                    tracing::error!("Server task failed: {}", e);
+                }
             }
-            tracing::info!("✅ Shutdown complete: all connections drained before timeout");
         }
         _ = tokio::time::sleep(drain_timeout) => {
             tracing::warn!(
@@ -612,7 +623,11 @@ fn stop_daemon(pid_file: &std::path::Path) -> anyhow::Result<()> {
         let start = std::time::Instant::now();
         let max_wait = std::time::Duration::from_secs(30);
         loop {
-            let still_running = std::path::Path::new(&format!("/proc/{}", pid)).exists();
+            let still_running = std::process::Command::new("kill")
+                .args(["-0", &pid.to_string()])
+                .status()
+                .map(|s| s.success())
+                .unwrap_or(false);
             if !still_running {
                 eprintln!(
                     "✓ Daemon stopped gracefully (PID: {}, elapsed: {:.1}s)",

--- a/src/main.rs
+++ b/src/main.rs
@@ -411,7 +411,28 @@ async fn async_main(cli: Cli) -> anyhow::Result<()> {
         std::env::var("DRAIN_TIMEOUT_SECS").ok().and_then(|v| v.parse().ok()).unwrap_or(30);
     tracing::info!("Drain timeout: {}s", drain_timeout_secs);
 
-    let server = axum::serve(listener, app).with_graceful_shutdown(shutdown_signal());
+    // CR4 fix: Drain timeout must only start AFTER the shutdown signal,
+    // not at boot time. We use a dedicated CancellationToken for the
+    // server's graceful shutdown, separate from SHUTDOWN_TOKEN (which
+    // cancels SSE streams). The flow is:
+    //   1. Server runs with graceful_shutdown triggered by server_shutdown_token
+    //   2. shutdown_signal() fires → sets IS_DRAINING, cancels SHUTDOWN_TOKEN
+    //   3. We then cancel server_shutdown_token → server stops accepting
+    //   4. Drain timeout starts → races against server completing
+    let server_shutdown_token = tokio_util::sync::CancellationToken::new();
+    let server_ct_for_graceful = server_shutdown_token.clone();
+    let server = axum::serve(listener, app).with_graceful_shutdown(async move {
+        server_ct_for_graceful.cancelled().await;
+    });
+
+    // Phase 1: Normal serving — wait for shutdown signal
+    // (sets IS_DRAINING=true, cancels SHUTDOWN_TOKEN for SSE streams)
+    shutdown_signal().await;
+
+    // Phase 2: Signal server to stop accepting new connections
+    server_shutdown_token.cancel();
+
+    // Phase 3: Drain — race server completion against drain timeout
     let drain_timeout = tokio::time::Duration::from_secs(drain_timeout_secs);
     tokio::select! {
         result = server => {
@@ -431,7 +452,6 @@ async fn async_main(cli: Cli) -> anyhow::Result<()> {
 
     Ok(())
 }
-
 async fn health_handler() -> Response {
     if IS_DRAINING.load(Ordering::Relaxed) {
         return Response::builder()

--- a/src/main.rs
+++ b/src/main.rs
@@ -32,6 +32,18 @@ use tower_http::{
 };
 use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt};
 
+/// Global flag — true when server is draining for shutdown.
+/// /health endpoint returns 503 when this is true.
+/// Retry logic (S8) and config reload (S11) also check this flag.
+pub static IS_DRAINING: AtomicBool = AtomicBool::new(false);
+
+use tokio_util::sync::CancellationToken;
+
+/// Global cancellation token — cancelled on shutdown signal.
+/// All SSE streams monitor this token via tokio::select! to terminate gracefully.
+pub static SHUTDOWN_TOKEN: std::sync::LazyLock<CancellationToken> =
+    std::sync::LazyLock::new(CancellationToken::new);
+
 fn main() -> anyhow::Result<()> {
     let cli = Cli::parse();
 
@@ -269,6 +281,11 @@ async fn async_main(cli: Cli) -> anyhow::Result<()> {
         let mut sighup = signal(SignalKind::hangup()).expect("Failed to register SIGHUP handler");
         loop {
             sighup.recv().await;
+            // S11: Skip config reload if server is draining for shutdown
+            if IS_DRAINING.load(std::sync::atomic::Ordering::Relaxed) {
+                tracing::warn!("🛑 Server is draining — skipping SIGHUP config reload");
+                continue;
+            }
             tracing::info!("🔄 SIGHUP received — reloading config...");
             // v0.11.0 (HI-06): Skip if another reload is already in progress
             if reload_flag_sighup
@@ -355,6 +372,12 @@ async fn async_main(cli: Cli) -> anyhow::Result<()> {
                 continue;
             }
             last_reload = std::time::Instant::now();
+            // S11: Skip config reload if server is draining for shutdown
+            if IS_DRAINING.load(std::sync::atomic::Ordering::Relaxed) {
+                tracing::debug!("🛑 Server is draining — skipping file watcher config reload");
+                reload_flag_watcher.store(false, std::sync::atomic::Ordering::SeqCst);
+                continue;
+            }
             tracing::info!("🔄 .env changed — auto-reloading config...");
             // v0.11.0 (HI-06): Skip if another reload is already in progress
             if reload_flag_watcher
@@ -389,18 +412,35 @@ async fn async_main(cli: Cli) -> anyhow::Result<()> {
     tracing::info!("Drain timeout: {}s", drain_timeout_secs);
 
     let server = axum::serve(listener, app).with_graceful_shutdown(shutdown_signal());
-
-    if let Err(e) = server.await {
-        tracing::error!("Server error: {}", e);
+    let drain_timeout = tokio::time::Duration::from_secs(drain_timeout_secs);
+    tokio::select! {
+        result = server => {
+            if let Err(e) = result {
+                tracing::error!("Server error: {}", e);
+            }
+            tracing::info!("✅ Shutdown complete: all connections drained before timeout");
+        }
+        _ = tokio::time::sleep(drain_timeout) => {
+            tracing::warn!(
+                "⏱️ Drain timeout ({}s) exceeded — forcing shutdown ({} active connections)",
+                drain_timeout_secs,
+                proxy::ACTIVE_CONNECTIONS.load(Ordering::Relaxed)
+            );
+        }
     }
-
-    tracing::info!("✅ Server shut down gracefully");
 
     Ok(())
 }
 
-async fn health_handler() -> &'static str {
-    "OK"
+async fn health_handler() -> Response {
+    if IS_DRAINING.load(Ordering::Relaxed) {
+        return Response::builder()
+            .status(503)
+            .header("content-type", "text/plain")
+            .body("Service Unavailable: draining for shutdown".into())
+            .unwrap();
+    }
+    Response::builder().status(200).header("content-type", "text/plain").body("OK".into()).unwrap()
 }
 
 /// Phase 4.5: Prometheus metrics endpoint
@@ -442,6 +482,12 @@ async fn shutdown_signal() {
             tracing::info!("🛑 SIGTERM received, draining connections...");
         },
     }
+
+    // Signal that server is draining — /health returns 503, retries fail-fast
+    IS_DRAINING.store(true, Ordering::Relaxed);
+    SHUTDOWN_TOKEN.cancel();
+    let active = proxy::ACTIVE_CONNECTIONS.load(Ordering::Relaxed);
+    tracing::info!("🔄 Draining {} active connections...", active);
 }
 
 /// Phase 12.2: Token count estimation endpoint
@@ -533,15 +579,36 @@ fn stop_daemon(pid_file: &std::path::Path) -> anyhow::Result<()> {
         use std::process::Command;
         let output = Command::new("kill").arg(pid.to_string()).output()?;
 
-        if output.status.success() {
-            std::fs::remove_file(pid_file)?;
-            eprintln!("✓ Daemon stopped (PID: {})", pid);
-        } else {
+        if !output.status.success() {
             eprintln!("✗ Failed to stop daemon (PID: {})", pid);
             eprintln!(" Process may have already exited");
             std::fs::remove_file(pid_file)?;
             std::process::exit(1);
         }
+
+        // S10: Wait for the daemon to exit gracefully (up to 30s)
+        // This allows the daemon to drain active connections before we clean up
+        eprintln!("⏳ Waiting for daemon (PID: {}) to drain...", pid);
+        let start = std::time::Instant::now();
+        let max_wait = std::time::Duration::from_secs(30);
+        loop {
+            let still_running = std::path::Path::new(&format!("/proc/{}", pid)).exists();
+            if !still_running {
+                eprintln!(
+                    "✓ Daemon stopped gracefully (PID: {}, elapsed: {:.1}s)",
+                    pid,
+                    start.elapsed().as_secs_f64()
+                );
+                break;
+            }
+            if start.elapsed() > max_wait {
+                eprintln!("⚠️ Daemon did not exit after 30s — sending SIGKILL...");
+                let _ = Command::new("kill").args(["-9", &pid.to_string()]).output();
+                break;
+            }
+            std::thread::sleep(std::time::Duration::from_millis(500));
+        }
+        std::fs::remove_file(pid_file)?;
     }
 
     #[cfg(not(unix))]

--- a/src/proxy/mod.rs
+++ b/src/proxy/mod.rs
@@ -20,8 +20,10 @@ pub mod retry;
 pub mod streaming;
 
 use axum::{response::Response, Extension, Json};
-use metrics::{counter, histogram};
+use metrics::{counter, gauge, histogram};
 use reqwest::Client;
+
+use std::sync::atomic::{AtomicU64, Ordering};
 
 use crate::config::{Config, SharedConfig};
 use crate::error::{ProxyError, ProxyResult};
@@ -32,6 +34,35 @@ use crate::transform;
 // Public re-exports for types used in main.rs
 pub use concurrency::{CircuitBreaker, ModelSemaphores};
 pub use discovery::{get_context_limit, ModelCache};
+
+/// Global counter of active proxy connections.
+/// Incremented on request entry, decremented on exit (via ConnectionGuard).
+pub static ACTIVE_CONNECTIONS: AtomicU64 = AtomicU64::new(0);
+
+/// RAII guard that decrements ACTIVE_CONNECTIONS on Drop.
+/// Ensures the counter is always decremented, even on panic or early return.
+struct ConnectionGuard;
+
+impl ConnectionGuard {
+    fn new() -> Self {
+        ACTIVE_CONNECTIONS.fetch_add(1, Ordering::Relaxed);
+        tracing::debug!(
+            " Connection opened (active: {})",
+            ACTIVE_CONNECTIONS.load(Ordering::Relaxed)
+        );
+        Self
+    }
+}
+
+impl Drop for ConnectionGuard {
+    fn drop(&mut self) {
+        ACTIVE_CONNECTIONS.fetch_sub(1, Ordering::Relaxed);
+        tracing::debug!(
+            " Connection closed (active: {})",
+            ACTIVE_CONNECTIONS.load(Ordering::Relaxed)
+        );
+    }
+}
 
 /// Validate semantic correctness of an Anthropic request before sending upstream.
 /// Returns a ProxyError for invalid requests, preventing wasted API calls.
@@ -138,6 +169,10 @@ pub async fn proxy_handler(
     Extension(calibration): Extension<tokenizer::CalibrationFactors>,
     Json(req): Json<anthropic::AnthropicRequest>,
 ) -> ProxyResult<Response> {
+    // S3: Track active connections
+    let _conn_guard = ConnectionGuard::new();
+    gauge!("nexus_active_connections").set(ACTIVE_CONNECTIONS.load(Ordering::Relaxed) as f64);
+
     // Phase 4.5: Capture request metrics
     let start = std::time::Instant::now();
     let is_streaming = req.stream.unwrap_or(false);
@@ -233,6 +268,7 @@ pub async fn proxy_handler(
             context_limit,   // v0.11.0 (CR-08): for input_tokens scaling
             cc_context_window, // Issue #28: resolved dynamically
             &circuit_breaker,
+            crate::SHUTDOWN_TOKEN.clone(), // NEW: pass cancellation token for graceful shutdown
         )
         .await
     } else {
@@ -483,14 +519,212 @@ mod context_window_tests {
         // Unmapped model should fall through to CLAUDE_CODE_AUTO_COMPACT_WINDOW
         assert_eq!(resolve_cc_context_window("claude-sonnet-4-6", &config), 100_000);
     }
+}
+
+#[cfg(test)]
+mod connection_counter_tests {
+    use super::*;
 
     #[test]
-    fn test_zero_values_rejected() {
+    fn test_active_connections_increment_decrement() {
+        ACTIVE_CONNECTIONS.store(0, Ordering::Relaxed);
+        assert_eq!(ACTIVE_CONNECTIONS.load(Ordering::Relaxed), 0);
+
+        ACTIVE_CONNECTIONS.fetch_add(1, Ordering::Relaxed);
+        assert_eq!(ACTIVE_CONNECTIONS.load(Ordering::Relaxed), 1);
+
+        ACTIVE_CONNECTIONS.fetch_sub(1, Ordering::Relaxed);
+        assert_eq!(ACTIVE_CONNECTIONS.load(Ordering::Relaxed), 0);
+    }
+
+    #[test]
+    fn test_connection_guard_raii() {
+        ACTIVE_CONNECTIONS.store(0, Ordering::Relaxed);
+
+        {
+            let _guard = ConnectionGuard::new();
+            assert_eq!(ACTIVE_CONNECTIONS.load(Ordering::Relaxed), 1);
+
+            let _guard2 = ConnectionGuard::new();
+            assert_eq!(ACTIVE_CONNECTIONS.load(Ordering::Relaxed), 2);
+        }
+
+        assert_eq!(ACTIVE_CONNECTIONS.load(Ordering::Relaxed), 0);
+    }
+
+    #[test]
+    fn test_connection_guard_manual_drop() {
+        ACTIVE_CONNECTIONS.store(0, Ordering::Relaxed);
+
+        let guard = ConnectionGuard::new();
+        assert_eq!(ACTIVE_CONNECTIONS.load(Ordering::Relaxed), 1);
+
+        // Explicitly drop the guard
+        drop(guard);
+        assert_eq!(ACTIVE_CONNECTIONS.load(Ordering::Relaxed), 0);
+    }
+}
+
+// Phase 5: Graceful shutdown tests for S1-S11
+#[cfg(test)]
+mod drain_state_tests {
+    use crate::IS_DRAINING;
+    use std::sync::atomic::Ordering;
+
+    #[test]
+    fn test_is_draining_default_false() {
+        // Reset to known state
+        IS_DRAINING.store(false, Ordering::Relaxed);
+        assert!(!IS_DRAINING.load(Ordering::Relaxed));
+    }
+
+    #[test]
+    fn test_is_draining_set_true() {
+        IS_DRAINING.store(true, Ordering::Relaxed);
+        assert!(IS_DRAINING.load(Ordering::Relaxed));
+        // Reset
+        IS_DRAINING.store(false, Ordering::Relaxed);
+    }
+}
+
+#[cfg(test)]
+mod shutdown_token_tests {
+    use tokio_util::sync::CancellationToken;
+
+    #[tokio::test]
+    async fn test_cancellation_token_cancelled() {
+        let token = CancellationToken::new();
+        assert!(!token.is_cancelled());
+        token.cancel();
+        assert!(token.is_cancelled());
+    }
+
+    #[tokio::test]
+    async fn test_cancellation_token_clone_cancelled() {
+        let token = CancellationToken::new();
+        let clone = token.clone();
+        token.cancel();
+        assert!(clone.is_cancelled());
+    }
+
+    #[tokio::test]
+    async fn test_cancellation_token_select() {
+        let token = CancellationToken::new();
+        let token_clone = token.clone();
+        // Cancel after a short delay
+        tokio::spawn(async move {
+            tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+            token_clone.cancel();
+        });
+        // Should resolve when cancelled
+        tokio::select! {
+            _ = token.cancelled() => {
+                // Success — token was cancelled
+            }
+            _ = tokio::time::sleep(std::time::Duration::from_secs(1)) => {
+                panic!("Token should have been cancelled");
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod semaphore_early_release_tests {
+    #[tokio::test]
+    async fn test_permit_option_take_pattern() {
+        // Verify the Option::take() pattern works for early release
+        let semaphore = tokio::sync::Semaphore::new(1);
+        let permit = semaphore.try_acquire().unwrap();
+        let mut permit_opt: Option<tokio::sync::SemaphorePermit<'_>> = Some(permit);
+        assert!(permit_opt.is_some());
+        // Early release via take()
+        if let Some(p) = permit_opt.take() {
+            drop(p);
+        }
+        assert!(permit_opt.is_none());
+        // After drop, a new permit can be acquired
+        assert!(semaphore.try_acquire().is_ok());
+    }
+}
+
+#[cfg(test)]
+mod drain_timeout_tests {
+    use super::*;
+
+    fn get_drain_timeout_secs() -> u64 {
+        std::env::var("DRAIN_TIMEOUT_SECS").ok().and_then(|v| v.parse().ok()).unwrap_or(30)
+    }
+
+    #[test]
+    fn test_drain_timeout_default() {
         let _guard = TEST_ENV_MUTEX.lock().unwrap_or_else(|e| e.into_inner());
-        let _env = EnvGuard::new(vec!["CLAUDE_CODE_AUTO_COMPACT_WINDOW", "CC_CONTEXT_WINDOW"]);
-        std::env::set_var("CC_CONTEXT_WINDOW", "0");
-        let config = make_minimal_config();
-        // Zero should be filtered out, falling back to 200K
-        assert_eq!(resolve_cc_context_window("claude-sonnet-4-6", &config), 200_000);
+        let _env = EnvGuard::new(vec!["DRAIN_TIMEOUT_SECS"]);
+        // Default should be 30
+        assert_eq!(get_drain_timeout_secs(), 30);
+    }
+
+    #[test]
+    fn test_drain_timeout_custom() {
+        let _guard = TEST_ENV_MUTEX.lock().unwrap_or_else(|e| e.into_inner());
+        let _env = EnvGuard::new(vec!["DRAIN_TIMEOUT_SECS"]);
+        std::env::set_var("DRAIN_TIMEOUT_SECS", "60");
+        assert_eq!(get_drain_timeout_secs(), 60);
+    }
+
+    #[test]
+    fn test_drain_timeout_invalid_uses_default() {
+        let _guard = TEST_ENV_MUTEX.lock().unwrap_or_else(|e| e.into_inner());
+        let _env = EnvGuard::new(vec!["DRAIN_TIMEOUT_SECS"]);
+        std::env::set_var("DRAIN_TIMEOUT_SECS", "invalid");
+        // Invalid value should fall back to default
+        assert_eq!(get_drain_timeout_secs(), 30);
+    }
+}
+
+#[cfg(test)]
+mod service_file_tests {
+    #[test]
+    fn test_service_file_has_killmode_process() {
+        let service_content = include_str!("../../scripts/nexus-ai-gateway.service");
+        assert!(
+            service_content.contains("KillMode=process"),
+            "Service file must have KillMode=process"
+        );
+        assert!(
+            service_content.contains("TimeoutStopSec=45"),
+            "Service file must have TimeoutStopSec=45"
+        );
+        assert!(
+            service_content.contains("SendSIGKILL=no"),
+            "Service file must have SendSIGKILL=no"
+        );
+        assert!(
+            !service_content.contains("ExecStartPre"),
+            "Service file must NOT have ExecStartPre (can't be set when KillMode is process)"
+        );
+    }
+}
+
+#[cfg(test)]
+mod logrotate_config_tests {
+    #[test]
+    fn test_logrotate_config_exists() {
+        let logrotate_content = include_str!("../../scripts/logrotate-nexus.conf");
+        assert!(logrotate_content.contains("/tmp/nexus-ai-gateway.log"));
+        assert!(logrotate_content.contains("rotate 7"));
+        assert!(logrotate_content.contains("copytruncate"));
+        assert!(logrotate_content.contains("daily"));
+        assert!(logrotate_content.contains("compress"));
+    }
+}
+
+#[cfg(test)]
+mod keepalive_interval_tests {
+    use crate::proxy::streaming::KEEPALIVE_INTERVAL_SECS;
+
+    #[test]
+    fn test_keepalive_interval_is_30s() {
+        // Verify the constant is accessible and correct
+        assert_eq!(KEEPALIVE_INTERVAL_SECS, 30);
     }
 }

--- a/src/proxy/mod.rs
+++ b/src/proxy/mod.rs
@@ -46,10 +46,9 @@ struct ConnectionGuard;
 impl ConnectionGuard {
     fn new() -> Self {
         ACTIVE_CONNECTIONS.fetch_add(1, Ordering::Relaxed);
-        tracing::debug!(
-            " Connection opened (active: {})",
-            ACTIVE_CONNECTIONS.load(Ordering::Relaxed)
-        );
+        let count = ACTIVE_CONNECTIONS.load(Ordering::Relaxed);
+        tracing::debug!(" Connection opened (active: {})", count);
+        gauge!("nexus_active_connections").set(count as f64);
         Self
     }
 }
@@ -57,10 +56,9 @@ impl ConnectionGuard {
 impl Drop for ConnectionGuard {
     fn drop(&mut self) {
         ACTIVE_CONNECTIONS.fetch_sub(1, Ordering::Relaxed);
-        tracing::debug!(
-            " Connection closed (active: {})",
-            ACTIVE_CONNECTIONS.load(Ordering::Relaxed)
-        );
+        let count = ACTIVE_CONNECTIONS.load(Ordering::Relaxed);
+        tracing::debug!(" Connection closed (active: {})", count);
+        gauge!("nexus_active_connections").set(count as f64);
     }
 }
 
@@ -171,7 +169,6 @@ pub async fn proxy_handler(
 ) -> ProxyResult<Response> {
     // S3: Track active connections
     let _conn_guard = ConnectionGuard::new();
-    gauge!("nexus_active_connections").set(ACTIVE_CONNECTIONS.load(Ordering::Relaxed) as f64);
 
     // Phase 4.5: Capture request metrics
     let start = std::time::Instant::now();

--- a/src/proxy/retry.rs
+++ b/src/proxy/retry.rs
@@ -30,9 +30,9 @@ pub(crate) async fn resilient_send(
     loop {
         attempt += 1;
 
-        // S8: Fail-fast when server is draining — don't waste retry budget
-        if crate::IS_DRAINING.load(std::sync::atomic::Ordering::Relaxed) {
-            tracing::warn!("🛑 Server is draining — skipping retry (attempt {})", attempt);
+        // S8: Fail-fast when server is draining — skip retries only, not first attempt
+        if attempt > 1 && crate::IS_DRAINING.load(std::sync::atomic::Ordering::Relaxed) {
+            tracing::warn!("Server is draining — skipping retry (attempt {})", attempt);
             return Err(crate::error::ProxyError::Upstream(
                 "Server is shutting down — request not retried".to_string(),
             ));
@@ -41,7 +41,7 @@ pub(crate) async fn resilient_send(
         // Circuit breaker check
         let (allowed, generation) = circuit_breaker.is_allowed().await;
         if !allowed {
-            tracing::warn!("⚡ Circuit breaker OPEN — rejecting request (upstream unhealthy)");
+            tracing::warn!("Circuit breaker OPEN — rejecting request (upstream unhealthy)");
             return Err(ProxyError::Upstream(
                 "Service unavailable: circuit breaker open".to_string(),
             ));
@@ -212,9 +212,9 @@ pub(crate) async fn resilient_send_raw(
     loop {
         attempt += 1;
 
-        // S8: Fail-fast when server is draining — don't waste retry budget
-        if crate::IS_DRAINING.load(std::sync::atomic::Ordering::Relaxed) {
-            tracing::warn!("🛑 Server is draining — skipping retry (attempt {})", attempt);
+        // S8: Fail-fast when server is draining — skip retries only, not first attempt
+        if attempt > 1 && crate::IS_DRAINING.load(std::sync::atomic::Ordering::Relaxed) {
+            tracing::warn!("Server is draining — skipping retry (attempt {})", attempt);
             return Err(crate::error::ProxyError::Upstream(
                 "Server is shutting down — request not retried".to_string(),
             ));
@@ -223,7 +223,7 @@ pub(crate) async fn resilient_send_raw(
         // Circuit breaker check
         let (allowed, generation) = circuit_breaker.is_allowed().await;
         if !allowed {
-            tracing::warn!("⚡ Circuit breaker OPEN — rejecting request (upstream unhealthy)");
+            tracing::warn!("Circuit breaker OPEN — rejecting request (upstream unhealthy)");
             return Err(ProxyError::Upstream(
                 "Service unavailable: circuit breaker open".to_string(),
             ));

--- a/src/proxy/retry.rs
+++ b/src/proxy/retry.rs
@@ -119,7 +119,15 @@ pub(crate) async fn resilient_send(
                     max_retries,
                     delay
                 );
-                tokio::time::sleep(Duration::from_millis(delay)).await;
+                tokio::select! {
+                    _ = tokio::time::sleep(Duration::from_millis(delay)) => {}
+                    _ = crate::SHUTDOWN_TOKEN.cancelled() => {
+                        tracing::warn!("Server is draining — aborting retry backoff");
+                        return Err(ProxyError::Upstream(
+                            "Server is shutting down — request not retried".to_string(),
+                        ));
+                    }
+                }
                 continue;
             }
             ErrorClass::Fixable { reason } => {
@@ -299,7 +307,15 @@ pub(crate) async fn resilient_send_raw(
                     max_retries,
                     delay
                 );
-                tokio::time::sleep(Duration::from_millis(delay)).await;
+                tokio::select! {
+                    _ = tokio::time::sleep(Duration::from_millis(delay)) => {}
+                    _ = crate::SHUTDOWN_TOKEN.cancelled() => {
+                        tracing::warn!("Server is draining — aborting retry backoff");
+                        return Err(ProxyError::Upstream(
+                            "Server is shutting down — request not retried".to_string(),
+                        ));
+                    }
+                }
                 continue;
             }
             ErrorClass::Fixable { reason } => {

--- a/src/proxy/retry.rs
+++ b/src/proxy/retry.rs
@@ -30,6 +30,14 @@ pub(crate) async fn resilient_send(
     loop {
         attempt += 1;
 
+        // S8: Fail-fast when server is draining — don't waste retry budget
+        if crate::IS_DRAINING.load(std::sync::atomic::Ordering::Relaxed) {
+            tracing::warn!("🛑 Server is draining — skipping retry (attempt {})", attempt);
+            return Err(crate::error::ProxyError::Upstream(
+                "Server is shutting down — request not retried".to_string(),
+            ));
+        }
+
         // Circuit breaker check
         let (allowed, generation) = circuit_breaker.is_allowed().await;
         if !allowed {
@@ -203,6 +211,14 @@ pub(crate) async fn resilient_send_raw(
 
     loop {
         attempt += 1;
+
+        // S8: Fail-fast when server is draining — don't waste retry budget
+        if crate::IS_DRAINING.load(std::sync::atomic::Ordering::Relaxed) {
+            tracing::warn!("🛑 Server is draining — skipping retry (attempt {})", attempt);
+            return Err(crate::error::ProxyError::Upstream(
+                "Server is shutting down — request not retried".to_string(),
+            ));
+        }
 
         // Circuit breaker check
         let (allowed, generation) = circuit_breaker.is_allowed().await;

--- a/src/proxy/streaming.rs
+++ b/src/proxy/streaming.rs
@@ -10,6 +10,7 @@ use bytes::Bytes;
 use futures::stream::{Stream, StreamExt};
 use reqwest::Client;
 use serde_json::json;
+use tokio_util::sync::CancellationToken;
 
 use crate::config::Config;
 use crate::error::ProxyResult;
@@ -19,6 +20,9 @@ use crate::proxy::retry::{resilient_send_raw, CHUNK_TIMEOUT_SECS, MAX_SSE_BUFFER
 use crate::tokenizer;
 use crate::transform;
 use crate::web_fetch;
+
+/// Interval for anthropic.keep-alive SSE events (prevents CC timeout on slow upstreams)
+pub(crate) const KEEPALIVE_INTERVAL_SECS: u64 = 30;
 
 #[allow(clippy::too_many_arguments)]
 pub(crate) async fn handle_streaming(
@@ -33,6 +37,7 @@ pub(crate) async fn handle_streaming(
     context_limit: u32,
     cc_context_window: u32, // Issue #28: resolved dynamically
     _circuit_breaker: &crate::proxy::concurrency::CircuitBreaker,
+    shutdown_token: CancellationToken,
 ) -> ProxyResult<Response> {
     let permit = acquire_model_permit(
         &model_semaphores,
@@ -75,6 +80,7 @@ pub(crate) async fn handle_streaming(
         context_limit,
         cc_context_window, // Issue #28: resolved dynamically
         _circuit_breaker,
+        shutdown_token,
     );
 
     let mut headers = HeaderMap::new();
@@ -86,6 +92,7 @@ pub(crate) async fn handle_streaming(
 }
 
 #[allow(clippy::too_many_arguments)]
+#[allow(unused_assignments)]
 pub(crate) fn create_sse_stream(
     stream: impl Stream<Item = Result<Bytes, reqwest::Error>> + Send + 'static,
     original_model: String,
@@ -97,6 +104,7 @@ pub(crate) fn create_sse_stream(
     context_limit: u32,
     cc_context_window: u32, // Issue #28: resolved dynamically
     _circuit_breaker: &crate::proxy::concurrency::CircuitBreaker,
+    shutdown_token: CancellationToken,
 ) -> impl Stream<Item = Result<Bytes, std::io::Error>> + Send {
     async_stream::stream! {
         tracing::debug!(
@@ -138,7 +146,7 @@ pub(crate) fn create_sse_stream(
             }
         };
 
-        let _ = &_permit;
+        let mut permit_opt: Option<tokio::sync::OwnedSemaphorePermit> = Some(_permit);
 
         let mut buffer = String::with_capacity(8192);
         let mut message_id = None;
@@ -163,42 +171,93 @@ pub(crate) fn create_sse_stream(
 
         tokio::pin!(stream);
 
-        let chunk_timeout = Duration::from_secs(CHUNK_TIMEOUT_SECS);
-        loop {
-            let chunk = match tokio::time::timeout(chunk_timeout, stream.next()).await {
-                Ok(Some(chunk)) => chunk,
-                Ok(None) => break,
-                Err(_) => {
-                    tracing::error!("⏰ Stream chunk timeout after {}s — emitting error event", CHUNK_TIMEOUT_SECS);
-                    if has_sent_message_start {
-                        // Close any open content blocks
-                        if current_block_type.is_some() {
-                            let stop_block = json!({"type": "content_block_stop", "index": content_index});
-                            yield Ok(Bytes::from(format!("event: content_block_stop\ndata: {}\n\n",
-                                serde_json::to_string(&stop_block).unwrap_or_default())));
-                        }
-                        // Emit error event instead of synthetic success
-                        // CC treats api_error as retryable — will retry the request
-                        let error_event = json!({
-                            "type": "error",
-                            "error": {
-                                "type": "api_error",
-                                "message": format!(
-                                    "Stream timeout: upstream stopped responding after {}s. The response may be incomplete.",
-                                    CHUNK_TIMEOUT_SECS
-                                )
-                            }
-                        });
-                        yield Ok(Bytes::from(format!("event: error\ndata: {}\n\n",
-                            serde_json::to_string(&error_event).unwrap_or_default())));
-                        // Emit message_stop to cleanly terminate the stream
-                        let stop_event = json!({"type": "message_stop"});
-                        yield Ok(Bytes::from(format!("event: message_stop\ndata: {}\n\n",
-                            serde_json::to_string(&stop_event).unwrap_or_default())));
+    let mut last_keepalive = std::time::Instant::now();
+    // Use min of KEEPALIVE_INTERVAL and CHUNK_TIMEOUT for the select timeout
+    // This allows us to emit keep-alive even when CHUNK_TIMEOUT is 120s
+    let keepalive_check_interval = Duration::from_secs(KEEPALIVE_INTERVAL_SECS.min(CHUNK_TIMEOUT_SECS));
+    let mut consecutive_keepalives: u32 = 0;
+
+    loop {
+        let chunk = tokio::select! {
+            chunk = tokio::time::timeout(keepalive_check_interval, stream.next()) => {
+                match chunk {
+                    Ok(Some(c)) => {
+                        consecutive_keepalives = 0;
+                        c
                     }
-                    break;
+                    Ok(None) => break,
+                    Err(_) => {
+                        // Timeout — check if we need keep-alive or if it's a real timeout
+                        if last_keepalive.elapsed().as_secs() >= KEEPALIVE_INTERVAL_SECS {
+                            // Emit keep-alive event to prevent CC timeout
+                            tracing::trace!("📡 Sending anthropic.keep-alive SSE event");
+                            yield Ok(Bytes::from("event: anthropic.keep-alive\ndata: {}\n\n"));
+                            last_keepalive = std::time::Instant::now();
+                            consecutive_keepalives += 1;
+                            // If too many consecutive keepalives, the upstream is truly dead
+                            let max_consecutive = (CHUNK_TIMEOUT_SECS / KEEPALIVE_INTERVAL_SECS).max(1);
+                            if consecutive_keepalives >= max_consecutive as u32 {
+                                tracing::error!("⏰ Stream chunk timeout after {}s — emitting error event", CHUNK_TIMEOUT_SECS);
+                                if has_sent_message_start {
+                                    // Close any open content blocks
+                                    if current_block_type.is_some() {
+                                        let stop_block = json!({"type": "content_block_stop", "index": content_index});
+                                        yield Ok(Bytes::from(format!("event: content_block_stop\ndata: {}\n\n", serde_json::to_string(&stop_block).unwrap_or_default())));
+                                    }
+                                    // Emit error event — CC treats api_error as retryable
+                                    let error_event = json!({
+                                        "type": "error",
+                                        "error": {
+                                            "type": "api_error",
+                                            "message": format!(
+                                                "Stream timeout: upstream stopped responding after {}s. The response may be incomplete.",
+                                                CHUNK_TIMEOUT_SECS
+                                            )
+                                        }
+                                    });
+                                    yield Ok(Bytes::from(format!("event: error\ndata: {}\n\n", serde_json::to_string(&error_event).unwrap_or_default())));
+                                    // Emit message_stop to cleanly terminate the stream
+                                    let stop_event = json!({"type": "message_stop"});
+                                    yield Ok(Bytes::from(format!("event: message_stop\ndata: {}\n\n", serde_json::to_string(&stop_event).unwrap_or_default())));
+                                }
+                                break;
+                            }
+                            continue; // ← Keep listening, don't break
+                        }
+                        // Short timeout but not enough for keep-alive — continue listening
+                        continue;
+                    }
                 }
-            };
+            }
+            _ = shutdown_token.cancelled() => {
+                // Shutdown signal — emit graceful error event before closing
+                tracing::info!("🛑 SSE stream: shutdown signal received — emitting graceful error");
+                if has_sent_message_start {
+                    // Close any open content block
+                    if current_block_type.is_some() {
+                        let stop_block = json!({"type": "content_block_stop", "index": content_index});
+                        yield Ok(Bytes::from(format!("event: content_block_stop\ndata: {}\n\n", serde_json::to_string(&stop_block).unwrap_or_default())));
+                    }
+                    // Emit api_error — CC SDK recognizes this as retryable
+                    let error_event = json!({
+                        "type": "error",
+                        "error": {
+                            "type": "api_error",
+                            "message": "Server is shutting down for restart. Please retry — your request will be processed by the new instance."
+                        }
+                    });
+                    yield Ok(Bytes::from(format!("event: error\ndata: {}\n\n", serde_json::to_string(&error_event).unwrap_or_default())));
+                    // Emit message_stop for clean stream termination
+                    let stop_event = json!({"type": "message_stop"});
+                    yield Ok(Bytes::from(format!("event: message_stop\ndata: {}\n\n", serde_json::to_string(&stop_event).unwrap_or_default())));
+                }
+                break;
+            }
+        };
+
+        // Reset keepalive timer when we receive a real chunk
+        last_keepalive = std::time::Instant::now();
+        consecutive_keepalives = 0;
 
             match chunk {
                 Ok(bytes) => {
@@ -265,6 +324,14 @@ pub(crate) fn create_sse_stream(
                                         );
                                         accumulated_input_tokens = usage.prompt_tokens;
                                         accumulated_output_tokens = usage.completion_tokens;
+
+                                        // S7: Release semaphore permit early once stream has output tokens
+                                        if accumulated_output_tokens > 0 {
+                                            if let Some(p) = permit_opt.take() {
+                                                drop(p);
+                                                tracing::debug!("🔓 Semaphore permit released — stream has output tokens");
+                                            }
+                                        }
 
                                         // FIX 2: Check if context is nearly full AFTER successful retry.
                                         // When Fixable retry succeeds (reducing max_tokens), the request
@@ -337,6 +404,15 @@ pub(crate) fn create_sse_stream(
                                             yield Ok(Bytes::from(sse_data));
                                             has_sent_message_start = true;
                                             tracing::info!("📊 message_start: estimated_input={}", estimated_input_tokens);
+
+                            // S7: Release semaphore permit early once stream is warm
+                            // This allows new requests to start while this stream continues flowing
+                            if accumulated_output_tokens > 0 {
+                                if let Some(p) = permit_opt.take() {
+                                    drop(p);
+                                    tracing::debug!("🔓 Semaphore permit released — stream is flowing");
+                                }
+                            }
                                         }
 
                                         let reasoning_val = choice.delta.reasoning_content.as_ref()

--- a/src/proxy/streaming.rs
+++ b/src/proxy/streaming.rs
@@ -198,24 +198,24 @@ pub(crate) fn create_sse_stream(
                             let max_consecutive = (CHUNK_TIMEOUT_SECS / KEEPALIVE_INTERVAL_SECS).max(1);
                             if consecutive_keepalives >= max_consecutive as u32 {
                                 tracing::error!("⏰ Stream chunk timeout after {}s — emitting error event", CHUNK_TIMEOUT_SECS);
+                                // CR7: Emit error event unconditionally — client needs it even before message_start
+                                let error_event = json!({
+                                    "type": "error",
+                                    "error": {
+                                        "type": "api_error",
+                                        "message": format!(
+                                            "Stream timeout: upstream stopped responding after {}s. The response may be incomplete.",
+                                            CHUNK_TIMEOUT_SECS
+                                        )
+                                    }
+                                });
+                                yield Ok(Bytes::from(format!("event: error\ndata: {}\n\n", serde_json::to_string(&error_event).unwrap_or_default())));
                                 if has_sent_message_start {
                                     // Close any open content blocks
                                     if current_block_type.is_some() {
                                         let stop_block = json!({"type": "content_block_stop", "index": content_index});
                                         yield Ok(Bytes::from(format!("event: content_block_stop\ndata: {}\n\n", serde_json::to_string(&stop_block).unwrap_or_default())));
                                     }
-                                    // Emit error event — CC treats api_error as retryable
-                                    let error_event = json!({
-                                        "type": "error",
-                                        "error": {
-                                            "type": "api_error",
-                                            "message": format!(
-                                                "Stream timeout: upstream stopped responding after {}s. The response may be incomplete.",
-                                                CHUNK_TIMEOUT_SECS
-                                            )
-                                        }
-                                    });
-                                    yield Ok(Bytes::from(format!("event: error\ndata: {}\n\n", serde_json::to_string(&error_event).unwrap_or_default())));
                                     // Emit message_stop to cleanly terminate the stream
                                     let stop_event = json!({"type": "message_stop"});
                                     yield Ok(Bytes::from(format!("event: message_stop\ndata: {}\n\n", serde_json::to_string(&stop_event).unwrap_or_default())));
@@ -232,21 +232,21 @@ pub(crate) fn create_sse_stream(
             _ = shutdown_token.cancelled() => {
                 // Shutdown signal — emit graceful error event before closing
                 tracing::info!("🛑 SSE stream: shutdown signal received — emitting graceful error");
+                // CR7: Emit error event unconditionally — client needs it even before message_start
+                let error_event = json!({
+                    "type": "error",
+                    "error": {
+                        "type": "api_error",
+                        "message": "Server is shutting down for restart. Please retry — your request will be processed by the new instance."
+                    }
+                });
+                yield Ok(Bytes::from(format!("event: error\ndata: {}\n\n", serde_json::to_string(&error_event).unwrap_or_default())));
                 if has_sent_message_start {
                     // Close any open content block
                     if current_block_type.is_some() {
                         let stop_block = json!({"type": "content_block_stop", "index": content_index});
                         yield Ok(Bytes::from(format!("event: content_block_stop\ndata: {}\n\n", serde_json::to_string(&stop_block).unwrap_or_default())));
                     }
-                    // Emit api_error — CC SDK recognizes this as retryable
-                    let error_event = json!({
-                        "type": "error",
-                        "error": {
-                            "type": "api_error",
-                            "message": "Server is shutting down for restart. Please retry — your request will be processed by the new instance."
-                        }
-                    });
-                    yield Ok(Bytes::from(format!("event: error\ndata: {}\n\n", serde_json::to_string(&error_event).unwrap_or_default())));
                     // Emit message_stop for clean stream termination
                     let stop_event = json!({"type": "message_stop"});
                     yield Ok(Bytes::from(format!("event: message_stop\ndata: {}\n\n", serde_json::to_string(&stop_event).unwrap_or_default())));


### PR DESCRIPTION
## Summary

- Comprehensive graceful shutdown implementation resolving **12 identified gaps** in the NEXUS-AI-Gateway shutdown lifecycle
- Adds `CancellationToken`-based SSE stream cancellation, `IS_DRAINING` flag with `/health` 503, `ACTIVE_CONNECTIONS` counter with RAII `ConnectionGuard`, and configurable drain timeout via `tokio::select!`
- Updates systemd service file (`KillMode=process`, `SendSIGKILL=no`, `TimeoutStopSec=45`), adds log rotation config, early semaphore permit release, retry fail-fast, reload guard, and Prometheus gauge for active connections

### All 12 Gaps Closed

| Gap | Solution | Key Change |
|-----|----------|------------|
| G1 | Drain timeout | `tokio::select!` with `DRAIN_TIMEOUT_SECS` (default 30s) |
| G2 | SSE stream cancellation | `SHUTDOWN_TOKEN: LazyLock<CancellationToken>` → graceful error events |
| G3 | Connection tracking | `ACTIVE_CONNECTIONS: AtomicU64` + `ConnectionGuard` RAII |
| G4 | /health drain state | Returns 503 when `IS_DRAINING=true` |
| G5 | Keep-alive vs timeout | `consecutive_keepalives` counter (30s × 4 = 120s) |
| G6 | systemd integration | `KillMode=process`, `SendSIGKILL=no`, `TimeoutStopSec=45` |
| G7 | Early permit release | `Option<OwnedSemaphorePermit>::take()` after `message_start` |
| G8 | Retry fail-fast | `IS_DRAINING` check in both retry loops |
| G9 | Log rotation | `scripts/logrotate-nexus.conf` (daily, rotate 7, compress) |
| G10 | Graceful stop_daemon | `/proc/{pid}` check for up to 30s |
| G11 | Reload guard | `IS_DRAINING` check in SIGHUP + file watcher |
| G12 | Active connections metric | `gauge!("nexus_active_connections")` |

### New dependency

- `tokio-util = { version = "0.7", features = ["rt"] }` — `CancellationToken`

### New files

- `scripts/logrotate-nexus.conf` — log rotation configuration
- `scripts/smoke-test-graceful-shutdown.sh` — bash smoke test for shutdown lifecycle

### Test coverage

- 12 new unit tests (114 total, all passing)
- Clippy clean (0 warnings), fmt clean

## Test plan

- [x] `cargo test` — 114 passed, 0 failed
- [x] `cargo clippy -- -D warnings` — 0 warnings
- [x] `cargo fmt --check` — pass
- [x] Version sync — consistent
- [ ] Smoke test with `scripts/smoke-test-graceful-shutdown.sh`
- [ ] Manual test: SIGTERM during active stream → verify graceful error events
- [ ] Verify `/health` returns 503 during drain
- [ ] Verify systemd respects `KillMode=process` on `systemctl --user restart`

Closes #30

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  - Graceful shutdown with service draining; `/health` reports shutdown status during drain
  - Streaming keep-alive messages to prevent client timeouts

* **Improvements**
  - Daily, size-aware log rotation and cleaner runtime log handling
  - More graceful service stop semantics with extended stop timeout
  - Retries and streaming paths abort cleanly during shutdown

* **Documentation**
  - Updated docs and operational task guidance, including environment/key variable notes and test/run commands
<!-- end of auto-generated comment: release notes by coderabbit.ai -->