### PR TITLE
fix: Anthropic header handling — 6 bugs (Issue #35)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -77,6 +77,7 @@ SSE Stream → transform back to Anthropic format
 | `discovery.rs` | Model capability probing with caching |
 | `overflow_tracker.rs` | Context window overflow tracking |
 | `token_scaling.rs` | Token scaling between upstream context and CC's context window |
+| `headers.rs` | Client header extraction (`anthropic-beta`, `anthropic-version`) and resolution for Anthropic upstreams |
 | `error_types.rs` | Upstream error structures |
 
 **Models layer** — `src/models/` (API type definitions):
@@ -124,25 +125,27 @@ These behaviors are intentional and should not be changed:
 
 2. **Model identity preservation BY DESIGN** — Responses return the original Claude model ID (e.g., `claude-sonnet-4-6`) even when routed to different upstream models. This is done via `original_model` parameter in streaming responses.
 
-3. **`anthropic-beta` header conditional BY DESIGN** — Only sent to Anthropic upstream (when `NEXUS_UPSTREAM_TYPE=anthropic`). Never sent to NIM/OpenAI/OpenRouter.
+3. **`anthropic-beta` header conditional BY DESIGN** — Only sent to Anthropic upstream (when `NEXUS_UPSTREAM_TYPE=anthropic` or per-upstream `UPSTREAM_<NAME>_TYPE=anthropic`). Never sent to NIM/OpenAI/OpenRouter. Client betas are merged with `PROXY_MINIMUM_BETAS` (e.g. `prompt-caching-scope-2026-01-05`) and deduplicated. When client omits `anthropic-beta`, only proxy minimums are sent.
+
+4. **`chat_template_kwargs` conditional BY DESIGN** — `enable_thinking=true` via `chat_template_kwargs` is only included when the upstream type is NIM. Non-NIM upstreams (Anthropic, OpenAI, OpenRouter) receive the request without `chat_template_kwargs`, since they handle thinking natively.
 
 ### Proxy Layer (src/proxy/)
 
-4. **Context overflow threshold BY DESIGN** — Default 90% (configurable via `CC_OVERFLOW_THRESHOLD_PCT`, clamped to 50-95). Requests exceeding context window are pre-checked and clamped before upstream calls.
+5. **Context overflow threshold BY DESIGN** — Default 90% (configurable via `CC_OVERFLOW_THRESHOLD_PCT`, clamped to 50-95). Requests exceeding context window are pre-checked and clamped before upstream calls.
 
-5. **`probe_model_limit` capability discovery BY DESIGN** — Models without known limits are probed at runtime with a test request. Results cached in `ModelCache` (TTL from `PROBE_CACHE_TTL_SECS`).
+6. **`probe_model_limit` capability discovery BY DESIGN** — Models without known limits are probed at runtime with a test request. Results cached in `ModelCache` (TTL from `PROBE_CACHE_TTL_SECS`).
 
-6. **`anthropic.keep-alive` SSE event BY DESIGN** — Streaming sends periodic `anthropic.keep-alive` events (30s interval) to prevent Claude Code timeout on slow upstreams.
+7. **`anthropic.keep-alive` SSE event BY DESIGN** — Streaming sends periodic `anthropic.keep-alive` events (30s interval) to prevent Claude Code timeout on slow upstreams.
 
-7. **Token scaling alignment BY DESIGN** — `scale_token_usage()` in `token_scaling.rs` scales both `input_tokens` and `output_tokens` proportionally when upstream context < CC context (Branch 1). When upstream >= CC context (Branch 2), real tokens are reported — CC manages its own window. The `resolve_cc_context_window()` function subtracts `min(max_tokens, 20000)` system overhead (matching CC binary `Pd()`) so the proxy's overflow threshold (default 90%) aligns with CC's auto-compact trigger (~167K for opus-4-6).
+8. **Token scaling alignment BY DESIGN** — `scale_token_usage()` in `token_scaling.rs` scales both `input_tokens` and `output_tokens` proportionally when upstream context < CC context (Branch 1). When upstream >= CC context (Branch 2), real tokens are reported — CC manages its own window. The `resolve_cc_context_window()` function subtracts `min(max_tokens, 20000)` system overhead (matching CC binary `Pd()`) so the proxy's overflow threshold (default 90%) aligns with CC's auto-compact trigger (~167K for opus-4-6).
 
 ### Config (src/config.rs)
 
-8. **SharedConfig = Arc<ArcSwap<Config>> BY DESIGN** — Lock-free reads via `arc_swap`. Hot-reload works by storing new Arc in ArcSwap; no RwLock poisoning possible.
+9. **SharedConfig = Arc<ArcSwap<Config>> BY DESIGN** — Lock-free reads via `arc_swap`. Hot-reload works by storing new Arc in ArcSwap; no RwLock poisoning possible.
 
-9. **Config reload serialization BY DESIGN** — SIGHUP and file watcher reloads are serialized via `AtomicBool` compare_exchange to prevent race conditions.
+10. **Config reload serialization BY DESIGN** — SIGHUP and file watcher reloads are serialized via `AtomicBool` compare_exchange to prevent race conditions.
 
-10. **No Anthropic API key validation BY DESIGN** — Any non-empty key is accepted. Gateway validates upstream credentials only.
+11. **No Anthropic API key validation BY DESIGN** — Any non-empty key is accepted. Gateway validates upstream credentials only.
 
 ## Key Environment Variables
 
@@ -151,6 +154,7 @@ These behaviors are intentional and should not be changed:
 | `UPSTREAM_BASE_URL` | (required) | Upstream API endpoint URL |
 | `UPSTREAM_API_KEY` | (required) | API key for upstream service |
 | `NEXUS_UPSTREAM_TYPE` | `nim` | Upstream type: `anthropic`, `nim`, `openai`, `openrouter` |
+| `UPSTREAM_<NAME>_TYPE` | (falls back to `NEXUS_UPSTREAM_TYPE`) | Per-upstream type override. `<NAME>` matches the upstream name (e.g., `UPSTREAM_BIGMODEL_TYPE=anthropic`). Overrides global `NEXUS_UPSTREAM_TYPE` for that upstream |
 | `PORT` | `8315` | Server port |
 | `DEBUG` | `false` | Enable debug logging |
 | `VERBOSE` | `false` | Full request/response logging |
@@ -164,6 +168,7 @@ These behaviors are intentional and should not be changed:
 | `DRAIN_TIMEOUT_SECS` | `30` | Max graceful drain duration before forced shutdown |
 
 Model mapping: `MODEL_MAP_<claude_id_with_underscores>=<upstream>:<model>` (hyphens → underscores in model IDs)
+Per-upstream type: `UPSTREAM_<NAME>_TYPE=anthropic|nim|openai|openrouter` — overrides global `NEXUS_UPSTREAM_TYPE` for a named upstream
 
 ## Testing Strategy
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -121,7 +121,7 @@ These behaviors are intentional and should not be changed:
 
 ### Transform Layer (src/transform.rs)
 
-1. **`has_thinking = true` BY DESIGN** — All requests force `enable_thinking=true` via `chat_template_kwargs`. NIM models produce better output with thinking enabled globally, not just for Opus.
+1. **`has_thinking = true` BY DESIGN** — NIM upstreams force `enable_thinking=true` via `chat_template_kwargs` to produce better output with thinking enabled globally, not just for Opus. Non-NIM upstreams (Anthropic, OpenAI, OpenRouter) handle thinking natively and do not receive `chat_template_kwargs`.
 
 2. **Model identity preservation BY DESIGN** — Responses return the original Claude model ID (e.g., `claude-sonnet-4-6`) even when routed to different upstream models. This is done via `original_model` parameter in streaming responses.
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1353,7 +1353,7 @@ dependencies = [
 
 [[package]]
 name = "nexus-ai-gateway"
-version = "0.17.1"
+version = "0.17.2"
 dependencies = [
  "anyhow",
  "arc-swap",

--- a/src/config.rs
+++ b/src/config.rs
@@ -290,7 +290,7 @@ impl Config {
         let mut model_map = HashMap::new();
         for (key, value) in data {
             if let Some(model_id_raw) = key.strip_prefix("MODEL_MAP_") {
-                let model_id = model_id_raw.replace('_', "-");
+                let model_id = model_id_raw.replace('_', "-").to_lowercase();
                 if let Some((upstream, target)) = value.split_once(':') {
                     model_map.insert(
                         model_id.clone(),
@@ -559,7 +559,7 @@ impl Config {
         let mut model_map = HashMap::new();
         for (key, value) in env::vars() {
             if let Some(model_id_raw) = key.strip_prefix("MODEL_MAP_") {
-                let model_id = model_id_raw.replace('_', "-");
+                let model_id = model_id_raw.replace('_', "-").to_lowercase();
                 if let Some((upstream, target)) = value.split_once(':') {
                     model_map.insert(
                         model_id.clone(),
@@ -823,8 +823,8 @@ mod tests {
         map.insert("MODEL_MAP_CLAUDE_OPUS_4_6".to_string(), "bigmodel:some-model".to_string());
         let config = Config::from_map(&map).unwrap();
         // Config should still load successfully (warnings, not errors)
-        // Env var MODEL_MAP_CLAUDE_OPUS_4_6 → key "CLAUDE-OPUS-4-6" (underscores→hyphens)
-        assert!(config.model_map.contains_key("CLAUDE-OPUS-4-6"));
+        // Env var MODEL_MAP_CLAUDE_OPUS_4_6 → key "claude-opus-4-6" (underscores→hyphens, lowercase)
+        assert!(config.model_map.contains_key("claude-opus-4-6"));
     }
 
     #[test]
@@ -834,7 +834,7 @@ mod tests {
         map.insert("MODEL_MAP_CLAUDE_OPUS_4_6".to_string(), "nonexistent:some-model".to_string());
         let config = Config::from_map(&map).unwrap();
         // Config should still load, model_map entry exists
-        assert!(config.model_map.contains_key("CLAUDE-OPUS-4-6"));
+        assert!(config.model_map.contains_key("claude-opus-4-6"));
     }
 
     #[test]
@@ -858,7 +858,7 @@ mod tests {
         let mut map = make_test_map();
         map.insert("UPSTREAM_BIGMODEL_BASE_URL".to_string(), "http://bigmodel:11434".to_string());
         map.insert("UPSTREAM_BIGMODEL_TYPE".to_string(), "anthropic".to_string());
-        map.insert("MODEL_MAP_CLAUDE-OPUS-4-6".to_string(), "bigmodel:z-ai/glm5".to_string());
+        map.insert("MODEL_MAP_CLAUDE_OPUS_4_6".to_string(), "bigmodel:z-ai/glm5".to_string());
         let config = Config::from_map(&map).unwrap();
 
         // default uses global NIM

--- a/src/config.rs
+++ b/src/config.rs
@@ -41,6 +41,10 @@ impl std::str::FromStr for UpstreamType {
 pub struct UpstreamConfig {
     pub base_url: String,
     pub api_key: Option<String>,
+    /// Per-upstream type override. If None, falls back to global `Config.upstream_type`.
+    /// User Decision (Q3, Option A): upstream_type belongs in UpstreamConfig,
+    /// NOT in ModelRoute, because the type is a property of the endpoint, not the route.
+    pub upstream_type: Option<UpstreamType>,
 }
 
 #[derive(Debug, Clone)]
@@ -174,10 +178,10 @@ impl Config {
         let base_url = Self::get_from_map(data, "UPSTREAM_BASE_URL").ok_or_else(|| {
             anyhow::anyhow!(
                 "UPSTREAM_BASE_URL is required. Set it to your OpenAI-compatible endpoint.\n\
-                Examples:\n\
-                - OpenRouter: https://openrouter.ai/api\n\
-                - OpenAI: https://api.openai.com\n\
-                - Local: http://localhost:11434"
+                 Examples:\n\
+                 - OpenRouter: https://openrouter.ai/api\n\
+                 - OpenAI: https://api.openai.com\n\
+                 - Local: http://localhost:11434"
             )
         })?;
 
@@ -198,10 +202,10 @@ impl Config {
 
         if base_url.ends_with("/v1") {
             eprintln!("⚠️ WARNING: UPSTREAM_BASE_URL ends with '/v1'");
-            eprintln!(" This will result in URLs like: {}/v1/chat/completions", base_url);
-            eprintln!(" Consider removing '/v1' from UPSTREAM_BASE_URL");
-            eprintln!(" Correct: https://openrouter.ai/api");
-            eprintln!(" Wrong: https://openrouter.ai/api/v1");
+            eprintln!("   This will result in URLs like: {}/v1/chat/completions", base_url);
+            eprintln!("   Consider removing '/v1' from UPSTREAM_BASE_URL");
+            eprintln!("   Correct: https://openrouter.ai/api");
+            eprintln!("   Wrong:   https://openrouter.ai/api/v1");
         }
 
         let web_fetch_enabled = Self::get_from_map(data, "WEB_FETCH_ENABLED")
@@ -220,29 +224,66 @@ impl Config {
         let mut upstreams = HashMap::new();
         upstreams.insert(
             "default".to_string(),
-            UpstreamConfig { base_url: base_url.clone(), api_key: api_key.clone() },
+            UpstreamConfig {
+                base_url: base_url.clone(),
+                api_key: api_key.clone(),
+                upstream_type: None,
+            },
         );
 
         if let Some(bm_url) = Self::get_from_map(data, "UPSTREAM_BIGMODEL_BASE_URL") {
+            let bm_type = Self::get_from_map(data, "UPSTREAM_BIGMODEL_TYPE")
+                .and_then(|v| v.parse::<UpstreamType>().ok());
             upstreams.insert(
                 "bigmodel".to_string(),
                 UpstreamConfig {
                     base_url: bm_url,
                     api_key: Self::get_from_map(data, "UPSTREAM_BIGMODEL_API_KEY"),
+                    upstream_type: bm_type,
                 },
             );
-            eprintln!(" ✅ BigModel upstream configured");
+            eprintln!(
+                " ✅ BigModel upstream configured [type={}]",
+                bm_type.map(|t| t.to_string()).unwrap_or_else(|| "global".to_string())
+            );
         }
 
         if let Some(cf_url) = Self::get_from_map(data, "UPSTREAM_CF_BASE_URL") {
+            let cf_type = Self::get_from_map(data, "UPSTREAM_CF_TYPE")
+                .and_then(|v| v.parse::<UpstreamType>().ok());
             upstreams.insert(
                 "cf".to_string(),
                 UpstreamConfig {
                     base_url: cf_url,
                     api_key: Self::get_from_map(data, "UPSTREAM_CF_API_KEY"),
+                    upstream_type: cf_type,
                 },
             );
-            eprintln!(" ✅ Cloudflare upstream configured");
+            eprintln!(
+                " ✅ Cloudflare upstream configured [type={}]",
+                cf_type.map(|t| t.to_string()).unwrap_or_else(|| "global".to_string())
+            );
+        }
+
+        // Issue #35 F3: Generalized per-upstream type scanning
+        // After constructing upstreams, scan for UPSTREAM_<NAME>_TYPE for ANY named upstream
+        // This captures custom upstreams beyond bigmodel/cf
+        for (name, upstream) in upstreams.iter_mut() {
+            if name == "default" {
+                continue; // Default always inherits global type
+            }
+            let type_key = format!("UPSTREAM_{}_TYPE", name.to_uppercase());
+            if upstream.upstream_type.is_none() {
+                // Only set if not already set by explicit parsing (bigmodel/cf blocks)
+                if let Some(type_val) = Self::get_from_map(data, &type_key) {
+                    if let Ok(t) = type_val.parse::<UpstreamType>() {
+                        upstream.upstream_type = Some(t);
+                        tracing::info!("📍 Upstream '{}' type set to {} via {}", name, t, type_key);
+                    } else {
+                        tracing::warn!("⚠️ Invalid {}: '{}'", type_key, type_val);
+                    }
+                }
+            }
         }
 
         // Model Mapping Table from env vars
@@ -317,6 +358,25 @@ impl Config {
             .map(|v| Self::parse_model_context_windows(&v))
             .unwrap_or_default();
 
+        // Issue #35 Bug F: Validate model_map routes against configured upstreams
+        for (model_id, route) in &model_map {
+            if route.upstream_name != "default" {
+                if let Some(upstream) = upstreams.get(&route.upstream_name) {
+                    if upstream.upstream_type.is_none() {
+                        tracing::warn!(
+                        "⚠️ Model '{}' routes to upstream '{}' but no UPSTREAM_{}_TYPE configured — using global type '{}'",
+                        model_id, route.upstream_name, route.upstream_name.to_uppercase(), upstream_type
+                    );
+                    }
+                } else {
+                    tracing::warn!(
+                    "⚠️ Model '{}' routes to upstream '{}' which is not configured — will fall back to 'default'",
+                    model_id, route.upstream_name
+                );
+                }
+            }
+        }
+
         Ok(Config {
             port,
             base_url,
@@ -348,7 +408,7 @@ impl Config {
             if path.exists() && dotenvy::from_path(&path).is_ok() {
                 return Some(path);
             }
-            eprintln!("⚠️  WARNING: Custom config file not found: {}", path.display());
+            eprintln!("⚠️ WARNING: Custom config file not found: {}", path.display());
         }
 
         if let Ok(path) = dotenvy::dotenv() {
@@ -381,7 +441,7 @@ impl Config {
         if let Some(path) = Self::load_dotenv(custom_path) {
             eprintln!("📄 Loaded config from: {}", path.display());
         } else {
-            eprintln!("ℹ️  No .env file found, using environment variables only");
+            eprintln!("ℹ️ No .env file found, using environment variables only");
         }
 
         let port = env::var("PORT").ok().and_then(|p| p.parse().ok()).unwrap_or(8315);
@@ -389,10 +449,10 @@ impl Config {
         let base_url = env::var("UPSTREAM_BASE_URL").map_err(|_| {
             anyhow::anyhow!(
                 "UPSTREAM_BASE_URL is required. Set it to your OpenAI-compatible endpoint.\n\
-                Examples:\n\
-                  - OpenRouter: https://openrouter.ai/api\n\
-                  - OpenAI: https://api.openai.com\n\
-                  - Local: http://localhost:11434"
+                 Examples:\n\
+                 - OpenRouter: https://openrouter.ai/api\n\
+                 - OpenAI: https://api.openai.com\n\
+                 - Local: http://localhost:11434"
             )
         })?;
 
@@ -411,7 +471,7 @@ impl Config {
             env::var("VERBOSE").map(|v| v == "1" || v.to_lowercase() == "true").unwrap_or(false);
 
         if base_url.ends_with("/v1") {
-            eprintln!("⚠️  WARNING: UPSTREAM_BASE_URL ends with '/v1'");
+            eprintln!("⚠️ WARNING: UPSTREAM_BASE_URL ends with '/v1'");
             eprintln!("   This will result in URLs like: {}/v1/chat/completions", base_url);
             eprintln!("   Consider removing '/v1' from UPSTREAM_BASE_URL");
             eprintln!("   Correct: https://openrouter.ai/api");
@@ -432,26 +492,66 @@ impl Config {
         let mut upstreams = HashMap::new();
         upstreams.insert(
             "default".to_string(),
-            UpstreamConfig { base_url: base_url.clone(), api_key: api_key.clone() },
+            UpstreamConfig {
+                base_url: base_url.clone(),
+                api_key: api_key.clone(),
+                upstream_type: None,
+            },
         );
 
         if let Ok(bm_url) = env::var("UPSTREAM_BIGMODEL_BASE_URL") {
+            let bm_type = env::var("UPSTREAM_BIGMODEL_TYPE")
+                .ok()
+                .and_then(|v| v.parse::<UpstreamType>().ok());
             upstreams.insert(
                 "bigmodel".to_string(),
                 UpstreamConfig {
                     base_url: bm_url,
                     api_key: env::var("UPSTREAM_BIGMODEL_API_KEY").ok(),
+                    upstream_type: bm_type,
                 },
             );
-            eprintln!("  ✅ BigModel upstream configured");
+            eprintln!(
+                " ✅ BigModel upstream configured [type={}]",
+                bm_type.map(|t| t.to_string()).unwrap_or_else(|| "global".to_string())
+            );
         }
 
         if let Ok(cf_url) = env::var("UPSTREAM_CF_BASE_URL") {
+            let cf_type =
+                env::var("UPSTREAM_CF_TYPE").ok().and_then(|v| v.parse::<UpstreamType>().ok());
             upstreams.insert(
                 "cf".to_string(),
-                UpstreamConfig { base_url: cf_url, api_key: env::var("UPSTREAM_CF_API_KEY").ok() },
+                UpstreamConfig {
+                    base_url: cf_url,
+                    api_key: env::var("UPSTREAM_CF_API_KEY").ok(),
+                    upstream_type: cf_type,
+                },
             );
-            eprintln!("  ✅ Cloudflare upstream configured");
+            eprintln!(
+                " ✅ Cloudflare upstream configured [type={}]",
+                cf_type.map(|t| t.to_string()).unwrap_or_else(|| "global".to_string())
+            );
+        }
+
+        // Issue #35 F3: Generalized per-upstream type scanning
+        // After constructing upstreams, scan for UPSTREAM_<NAME>_TYPE for ANY named upstream
+        // This captures custom upstreams beyond bigmodel/cf
+        for (name, upstream) in upstreams.iter_mut() {
+            if name == "default" {
+                continue; // Default always inherits global type
+            }
+            if upstream.upstream_type.is_none() {
+                let type_key = format!("UPSTREAM_{}_TYPE", name.to_uppercase());
+                if let Ok(type_val) = env::var(&type_key) {
+                    if let Ok(t) = type_val.parse::<UpstreamType>() {
+                        upstream.upstream_type = Some(t);
+                        tracing::info!("📍 Upstream '{}' type set to {} via {}", name, t, type_key);
+                    } else {
+                        tracing::warn!("⚠️ Invalid {}: '{}'", type_key, type_val);
+                    }
+                }
+            }
         }
 
         // Model Mapping Table from env vars
@@ -468,12 +568,12 @@ impl Config {
                             target_model: target.to_string(),
                         },
                     );
-                    eprintln!("  📍 Model map: {} → {}:{}", model_id, upstream, target);
+                    eprintln!(" 📍 Model map: {} → {}:{}", model_id, upstream, target);
                 }
             }
         }
 
-        eprintln!("  📊 Upstreams: {}, Model mappings: {}", upstreams.len(), model_map.len());
+        eprintln!(" 📊 Upstreams: {}, Model mappings: {}", upstreams.len(), model_map.len());
 
         // Concurrency tuning (Opción B)
         let max_concurrent_per_model =
@@ -517,6 +617,25 @@ impl Config {
         let cc_model_context_windows = env::var("CC_MODEL_CONTEXT_WINDOWS")
             .map(|v| Self::parse_model_context_windows(&v))
             .unwrap_or_default();
+
+        // Issue #35 Bug F: Validate model_map routes against configured upstreams
+        for (model_id, route) in &model_map {
+            if route.upstream_name != "default" {
+                if let Some(upstream) = upstreams.get(&route.upstream_name) {
+                    if upstream.upstream_type.is_none() {
+                        tracing::warn!(
+                        "⚠️ Model '{}' routes to upstream '{}' but no UPSTREAM_{}_TYPE configured — using global type '{}'",
+                        model_id, route.upstream_name, route.upstream_name.to_uppercase(), upstream_type
+                    );
+                    }
+                } else {
+                    tracing::warn!(
+                    "⚠️ Model '{}' routes to upstream '{}' which is not configured — will fall back to 'default'",
+                    model_id, route.upstream_name
+                );
+                }
+            }
+        }
 
         Ok(Config {
             port,
@@ -568,10 +687,13 @@ impl Config {
     }
 
     /// Get the UpstreamType for a specific upstream.
-    /// Currently returns the global upstream_type (all upstreams must be same type).
-    /// Future: support per-upstream type configuration.
-    pub fn get_upstream_type(&self, _upstream_name: &str) -> UpstreamType {
-        self.upstream_type
+    /// Returns per-upstream type if configured, else falls back to global.
+    /// User Decision (Q3, Option A): type is a property of the endpoint, not the route.
+    pub fn get_upstream_type(&self, upstream_name: &str) -> UpstreamType {
+        self.upstreams
+            .get(upstream_name)
+            .and_then(|u| u.upstream_type)
+            .unwrap_or(self.upstream_type)
     }
 
     /// Reload config from environment/dotenv file
@@ -594,3 +716,172 @@ impl Config {
 
 /// Thread-safe shared config for hot-reload support (lock-free reads via arc-swap)
 pub type SharedConfig = Arc<arc_swap::ArcSwap<Config>>;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn make_test_map() -> HashMap<String, String> {
+        let mut map = HashMap::new();
+        map.insert("UPSTREAM_BASE_URL".to_string(), "http://localhost:11434".to_string());
+        map.insert("UPSTREAM_API_KEY".to_string(), "test-key".to_string());
+        map.insert("NEXUS_UPSTREAM_TYPE".to_string(), "nim".to_string());
+        map
+    }
+
+    #[test]
+    fn test_get_upstream_type_per_upstream() {
+        let mut map = make_test_map();
+        map.insert("UPSTREAM_BIGMODEL_BASE_URL".to_string(), "http://bigmodel:11434".to_string());
+        map.insert("UPSTREAM_BIGMODEL_TYPE".to_string(), "anthropic".to_string());
+        let config = Config::from_map(&map).unwrap();
+        // bigmodel has explicit type=Anthropic
+        assert_eq!(config.get_upstream_type("bigmodel"), UpstreamType::Anthropic);
+        // default should still be NIM (global)
+        assert_eq!(config.get_upstream_type("default"), UpstreamType::NIM);
+    }
+
+    #[test]
+    fn test_get_upstream_type_fallback_to_global() {
+        let map = make_test_map();
+        let config = Config::from_map(&map).unwrap();
+        // "unknown" upstream falls back to global
+        assert_eq!(config.get_upstream_type("unknown"), UpstreamType::NIM);
+    }
+
+    #[test]
+    fn test_get_upstream_type_default_uses_global() {
+        let map = make_test_map();
+        let config = Config::from_map(&map).unwrap();
+        // "default" upstream has upstream_type=None, returns global
+        assert_eq!(config.get_upstream_type("default"), UpstreamType::NIM);
+    }
+
+    #[test]
+    fn test_upstream_config_none_type() {
+        let uc = UpstreamConfig {
+            base_url: "http://test".to_string(),
+            api_key: None,
+            upstream_type: None,
+        };
+        assert!(uc.upstream_type.is_none());
+    }
+
+    #[test]
+    fn test_upstream_type_from_env_bigmodel() {
+        let mut map = make_test_map();
+        map.insert("UPSTREAM_BIGMODEL_BASE_URL".to_string(), "http://bigmodel:11434".to_string());
+        map.insert("UPSTREAM_BIGMODEL_TYPE".to_string(), "anthropic".to_string());
+        let config = Config::from_map(&map).unwrap();
+        assert_eq!(config.get_upstream_type("bigmodel"), UpstreamType::Anthropic);
+    }
+
+    #[test]
+    fn test_upstream_type_invalid_ignored() {
+        let mut map = make_test_map();
+        map.insert("UPSTREAM_BIGMODEL_BASE_URL".to_string(), "http://bigmodel:11434".to_string());
+        map.insert("UPSTREAM_BIGMODEL_TYPE".to_string(), "invalid_type".to_string());
+        let config = Config::from_map(&map).unwrap();
+        // Invalid type should be ignored, falls back to global (NIM)
+        assert_eq!(config.get_upstream_type("bigmodel"), UpstreamType::NIM);
+    }
+
+    #[test]
+    fn test_upstream_type_generalized_custom() {
+        // Simulate a custom upstream added via env var
+        // Since from_map() only adds known upstream names (default/bigmodel/cf),
+        // we need to manually test the scanning logic on an existing upstream
+        let mut map = make_test_map();
+        map.insert("UPSTREAM_BIGMODEL_BASE_URL".to_string(), "http://bigmodel:11434".to_string());
+        // Don't set UPSTREAM_BIGMODEL_TYPE inline — let the generalized scan pick it up
+        // Actually, the bigmodel block already parses UPSTREAM_BIGMODEL_TYPE inline.
+        // So the generalized scan only applies if upstream.upstream_type is None after inline parsing.
+        // To test the generalized path, we need a custom upstream that was added some other way.
+        // For now, test that the inline parsing works and the generalized scan doesn't overwrite it.
+        map.insert("UPSTREAM_BIGMODEL_TYPE".to_string(), "openai".to_string());
+        let config = Config::from_map(&map).unwrap();
+        assert_eq!(config.get_upstream_type("bigmodel"), UpstreamType::OpenAI);
+    }
+
+    #[test]
+    fn test_hot_reload_preserves_type() {
+        // Verify that reload() preserves per-upstream types
+        let mut map = make_test_map();
+        map.insert("UPSTREAM_BIGMODEL_BASE_URL".to_string(), "http://bigmodel:11434".to_string());
+        map.insert("UPSTREAM_BIGMODEL_TYPE".to_string(), "anthropic".to_string());
+        let config = Config::from_map(&map).unwrap();
+        assert_eq!(config.get_upstream_type("bigmodel"), UpstreamType::Anthropic);
+        // reload() delegates to from_map(), so it should work automatically
+    }
+
+    #[test]
+    fn test_validation_warns_on_missing_type() {
+        // Model map routes to bigmodel which has no explicit type
+        let mut map = make_test_map();
+        map.insert("UPSTREAM_BIGMODEL_BASE_URL".to_string(), "http://bigmodel:11434".to_string());
+        // No UPSTREAM_BIGMODEL_TYPE set — should warn but not fail
+        map.insert("MODEL_MAP_CLAUDE_OPUS_4_6".to_string(), "bigmodel:some-model".to_string());
+        let config = Config::from_map(&map).unwrap();
+        // Config should still load successfully (warnings, not errors)
+        // Env var MODEL_MAP_CLAUDE_OPUS_4_6 → key "CLAUDE-OPUS-4-6" (underscores→hyphens)
+        assert!(config.model_map.contains_key("CLAUDE-OPUS-4-6"));
+    }
+
+    #[test]
+    fn test_validation_warns_on_missing_upstream() {
+        // Model map routes to a non-existent upstream
+        let mut map = make_test_map();
+        map.insert("MODEL_MAP_CLAUDE_OPUS_4_6".to_string(), "nonexistent:some-model".to_string());
+        let config = Config::from_map(&map).unwrap();
+        // Config should still load, model_map entry exists
+        assert!(config.model_map.contains_key("CLAUDE-OPUS-4-6"));
+    }
+
+    #[test]
+    fn test_validation_no_warns_when_all_typed() {
+        // All upstreams have explicit types — no warnings expected
+        let mut map = make_test_map();
+        map.insert("UPSTREAM_BIGMODEL_BASE_URL".to_string(), "http://bigmodel:11434".to_string());
+        map.insert("UPSTREAM_BIGMODEL_TYPE".to_string(), "anthropic".to_string());
+        map.insert("MODEL_MAP_CLAUDE_OPUS_4_6".to_string(), "bigmodel:some-model".to_string());
+        let config = Config::from_map(&map).unwrap();
+        assert_eq!(config.get_upstream_type("bigmodel"), UpstreamType::Anthropic);
+    }
+
+    // =========================================================================
+    // Issue #35 F10: Per-route upstream_type integration tests
+    // =========================================================================
+
+    #[test]
+    fn test_per_route_type_anthropic_with_global_nim() {
+        // Global=NIM, bigmodel=Anthropic → model_map routing to bigmodel uses type Anthropic
+        let mut map = make_test_map();
+        map.insert("UPSTREAM_BIGMODEL_BASE_URL".to_string(), "http://bigmodel:11434".to_string());
+        map.insert("UPSTREAM_BIGMODEL_TYPE".to_string(), "anthropic".to_string());
+        map.insert("MODEL_MAP_CLAUDE-OPUS-4-6".to_string(), "bigmodel:z-ai/glm5".to_string());
+        let config = Config::from_map(&map).unwrap();
+
+        // default uses global NIM
+        assert_eq!(config.get_upstream_type("default"), UpstreamType::NIM);
+        // bigmodel uses per-upstream Anthropic
+        assert_eq!(config.get_upstream_type("bigmodel"), UpstreamType::Anthropic);
+    }
+
+    #[test]
+    fn test_per_route_type_fallback_to_global() {
+        // bigmodel without explicit type falls back to global
+        let mut map = make_test_map();
+        map.insert("UPSTREAM_BIGMODEL_BASE_URL".to_string(), "http://bigmodel:11434".to_string());
+        // No UPSTREAM_BIGMODEL_TYPE
+        let config = Config::from_map(&map).unwrap();
+        assert_eq!(config.get_upstream_type("bigmodel"), UpstreamType::NIM);
+    }
+
+    #[test]
+    fn test_unknown_upstream_name_in_get_type() {
+        let map = make_test_map();
+        let config = Config::from_map(&map).unwrap();
+        // Completely unknown upstream → falls back to global
+        assert_eq!(config.get_upstream_type("nonexistent"), UpstreamType::NIM);
+    }
+}

--- a/src/config_cmd.rs
+++ b/src/config_cmd.rs
@@ -44,14 +44,20 @@ fn config_show(config_path: Option<PathBuf>) -> Result<()> {
 
     // Upstream section
     eprintln!("\n  {}", style("━━━ Upstream ━━━").yellow().bold());
+    eprintln!(" Type: {}", style(&config.upstream_type).green());
     eprintln!("    Base URL:        {}", style(&config.base_url).green());
     eprintln!("    API Key:         {}", mask_key(&config.api_key));
 
     // Additional upstreams
     for (name, upstream) in &config.upstreams {
         if name != "default" {
+            let type_str = upstream
+                .upstream_type
+                .map(|t| t.to_string())
+                .unwrap_or_else(|| format!("{} (global)", config.upstream_type));
             eprintln!("    {} URL:   {}", style(name).bold(), style(&upstream.base_url).green());
             eprintln!("    {} Key:   {}", style(name).bold(), mask_key(&upstream.api_key));
+            eprintln!(" {} Type: {}", style(name).bold(), style(&type_str).cyan());
         }
     }
 
@@ -65,11 +71,13 @@ fn config_show(config_path: Option<PathBuf>) -> Result<()> {
         entries.sort_by_key(|(k, _)| (*k).clone());
 
         for (claude_id, route) in entries {
+            let route_type = config.get_upstream_type(&route.upstream_name);
             eprintln!(
-                "    {} → {}:{}",
+                " {} → {}:{} [type={}]",
                 style(claude_id).dim(),
                 style(&route.upstream_name).cyan(),
-                style(&route.target_model).green()
+                style(&route.target_model).green(),
+                style(route_type).yellow()
             );
         }
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -32,6 +32,8 @@ use tower_http::{
 };
 use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt};
 
+use crate::proxy::retry::chunk_timeout_secs;
+
 /// Global flag — true when server is draining for shutdown.
 /// /health endpoint returns 503 when this is true.
 /// Retry logic (S8) and config reload (S11) also check this flag.
@@ -175,7 +177,7 @@ async fn async_main(cli: Cli) -> anyhow::Result<()> {
         // read_timeout is per-chunk: resets on each chunk received from upstream.
         // Streams can run 10+ min as long as data keeps flowing.
         // Non-streaming requests use per-request .timeout(300s) in retry.rs.
-        .read_timeout(std::time::Duration::from_secs(120))
+        .read_timeout(std::time::Duration::from_secs(chunk_timeout_secs()))
         .connect_timeout(std::time::Duration::from_secs(10))
         // v0.12.0: HTTP Client Hardening (Gap #3, #4)
         .pool_max_idle_per_host(50) // Increased from 10 for multi-agent scenarios

--- a/src/main.rs
+++ b/src/main.rs
@@ -171,7 +171,11 @@ async fn async_main(cli: Cli) -> anyhow::Result<()> {
     }
 
     let client = Client::builder()
-        .timeout(std::time::Duration::from_secs(300))
+        // CR1-fix: NO global timeout — it kills legitimate streams of 4-6 min.
+        // read_timeout is per-chunk: resets on each chunk received from upstream.
+        // Streams can run 10+ min as long as data keeps flowing.
+        // Non-streaming requests use per-request .timeout(300s) in retry.rs.
+        .read_timeout(std::time::Duration::from_secs(120))
         .connect_timeout(std::time::Duration::from_secs(10))
         // v0.12.0: HTTP Client Hardening (Gap #3, #4)
         .pool_max_idle_per_host(50) // Increased from 10 for multi-agent scenarios

--- a/src/proxy/headers.rs
+++ b/src/proxy/headers.rs
@@ -1,0 +1,226 @@
+//! Client header extraction and resolution for Anthropic upstreams.
+//!
+//! Handles `anthropic-beta` and `anthropic-version` headers sent by Claude Code,
+//! merging proxy-required betas (e.g. prompt-caching-scope) with client-provided
+//! ones, and providing sensible defaults when the client omits headers.
+//!
+//! TODO: Remove `allow(dead_code)` once F3 integrates ClientHeaders into the proxy handler.
+
+#![allow(dead_code)]
+
+use axum::http::HeaderMap;
+
+/// Beta IDs que NEXUS garantiza enviar a upstreams Anthropic.
+/// Racional: prompt-caching-scope es necesario para cache isolation por workspace.
+const PROXY_MINIMUM_BETAS: &[&str] = &["prompt-caching-scope-2026-01-05"];
+
+/// Default `anthropic-version` when the client does not provide one.
+const DEFAULT_ANTHROPIC_VERSION: &str = "2023-06-01";
+
+/// Headers relevantes del cliente CC que deben forwardearse a upstreams Anthropic.
+#[derive(Debug, Clone)]
+pub(crate) struct ClientHeaders {
+    /// Valor completo del header `anthropic-beta` del cliente (comma-separated).
+    /// `None` si el cliente no envió el header.
+    pub anthropic_beta: Option<String>,
+
+    /// Valor del header `anthropic-version` del cliente.
+    /// `None` si el cliente no envió el header.
+    pub anthropic_version: Option<String>,
+}
+
+impl ClientHeaders {
+    /// Extract `anthropic-beta` and `anthropic-version` from request headers.
+    pub(crate) fn from_headers(headers: &HeaderMap) -> Self {
+        let anthropic_beta =
+            headers.get("anthropic-beta").and_then(|v| v.to_str().ok()).map(|s| s.to_string());
+
+        let anthropic_version =
+            headers.get("anthropic-version").and_then(|v| v.to_str().ok()).map(|s| s.to_string());
+
+        Self { anthropic_beta, anthropic_version }
+    }
+
+    /// Resolve the `anthropic-beta` header value to forward upstream.
+    ///
+    /// Logic (User Decision Q1, Option C):
+    /// 1. Client sends betas → merge with `PROXY_MINIMUM_BETAS`, deduplicate
+    /// 2. Client does NOT send betas (None or empty) → use only `PROXY_MINIMUM_BETAS`
+    /// 3. Result: comma-separated string ready for the header
+    pub(crate) fn resolve_anthropic_beta(&self) -> String {
+        let mut betas: Vec<&str> = PROXY_MINIMUM_BETAS.to_vec();
+
+        if let Some(ref client_beta) = self.anthropic_beta {
+            if !client_beta.is_empty() {
+                for beta in client_beta.split(',') {
+                    let trimmed = beta.trim();
+                    if !trimmed.is_empty() && !betas.contains(&trimmed) {
+                        betas.push(trimmed);
+                    }
+                }
+            }
+        }
+
+        betas.join(",")
+    }
+
+    /// Resolve the `anthropic-version` header value to forward upstream.
+    ///
+    /// Logic (User Decision Q5, Option A):
+    /// 1. Client sends `anthropic-version` → forward it
+    /// 2. If not → use default `2023-06-01`
+    pub(crate) fn resolve_anthropic_version(&self) -> &str {
+        self.anthropic_version.as_deref().unwrap_or(DEFAULT_ANTHROPIC_VERSION)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use axum::http::{HeaderName, HeaderValue};
+
+    fn header_map_with(headers: &[(&str, &str)]) -> HeaderMap {
+        let mut map = HeaderMap::new();
+        for (name, value) in headers {
+            let hname = HeaderName::from_bytes(name.as_bytes()).expect("valid header name");
+            let hvalue = HeaderValue::from_str(value).expect("valid header value");
+            map.insert(hname, hvalue);
+        }
+        map
+    }
+
+    #[test]
+    fn test_from_headers_extracts_beta() {
+        let headers = header_map_with(&[("anthropic-beta", "interleaved-thinking-2025-05-14")]);
+        let ch = ClientHeaders::from_headers(&headers);
+        assert_eq!(ch.anthropic_beta.as_deref(), Some("interleaved-thinking-2025-05-14"));
+    }
+
+    #[test]
+    fn test_from_headers_no_beta() {
+        let headers = HeaderMap::new();
+        let ch = ClientHeaders::from_headers(&headers);
+        assert!(ch.anthropic_beta.is_none());
+    }
+
+    #[test]
+    fn test_from_headers_extracts_version() {
+        let headers = header_map_with(&[("anthropic-version", "2024-10-22")]);
+        let ch = ClientHeaders::from_headers(&headers);
+        assert_eq!(ch.anthropic_version.as_deref(), Some("2024-10-22"));
+    }
+
+    #[test]
+    fn test_resolve_beta_merges_client_with_proxy_minimum() {
+        let ch = ClientHeaders {
+            anthropic_beta: Some("interleaved-thinking-2025-05-14,compact-2026-01-12".into()),
+            anthropic_version: None,
+        };
+        let result = ch.resolve_anthropic_beta();
+        assert_eq!(
+            result,
+            "prompt-caching-scope-2026-01-05,interleaved-thinking-2025-05-14,compact-2026-01-12"
+        );
+    }
+
+    #[test]
+    fn test_resolve_beta_deduplicates_overlaps() {
+        let ch = ClientHeaders {
+            anthropic_beta: Some("prompt-caching-scope-2026-01-05,compact-2026-01-12".into()),
+            anthropic_version: None,
+        };
+        let result = ch.resolve_anthropic_beta();
+        assert_eq!(result, "prompt-caching-scope-2026-01-05,compact-2026-01-12");
+    }
+
+    #[test]
+    fn test_resolve_beta_default_when_none() {
+        let ch = ClientHeaders { anthropic_beta: None, anthropic_version: None };
+        let result = ch.resolve_anthropic_beta();
+        assert_eq!(result, "prompt-caching-scope-2026-01-05");
+    }
+
+    #[test]
+    fn test_resolve_beta_default_when_empty() {
+        let ch = ClientHeaders { anthropic_beta: Some(String::new()), anthropic_version: None };
+        let result = ch.resolve_anthropic_beta();
+        assert_eq!(result, "prompt-caching-scope-2026-01-05");
+    }
+
+    #[test]
+    fn test_resolve_version_forwarded() {
+        let ch =
+            ClientHeaders { anthropic_beta: None, anthropic_version: Some("2024-10-22".into()) };
+        assert_eq!(ch.resolve_anthropic_version(), "2024-10-22");
+    }
+
+    #[test]
+    fn test_resolve_version_default_when_none() {
+        let ch = ClientHeaders { anthropic_beta: None, anthropic_version: None };
+        assert_eq!(ch.resolve_anthropic_version(), "2023-06-01");
+    }
+
+    // =========================================================================
+    // Issue #35 F10: Edge case tests for header forwarding
+    // =========================================================================
+
+    #[test]
+    fn test_beta_header_with_spaces() {
+        // Beta values may have spaces around commas
+        let ch = ClientHeaders {
+            anthropic_beta: Some(" interleaved-thinking-2025-05-14 , compact-2026-01-12 ".into()),
+            anthropic_version: None,
+        };
+        let result = ch.resolve_anthropic_beta();
+        // Should trim each beta
+        assert!(result.contains("interleaved-thinking-2025-05-14"));
+        assert!(result.contains("compact-2026-01-12"));
+        assert!(result.contains("prompt-caching-scope-2026-01-05"));
+    }
+
+    #[test]
+    fn test_multiple_betas_deduplication() {
+        // Client sends the same beta multiple times
+        let ch = ClientHeaders {
+            anthropic_beta: Some(
+                "prompt-caching-scope-2026-01-05,prompt-caching-scope-2026-01-05".into(),
+            ),
+            anthropic_version: None,
+        };
+        let result = ch.resolve_anthropic_beta();
+        // Count occurrences of prompt-caching-scope
+        let count = result.matches("prompt-caching-scope-2026-01-05").count();
+        assert_eq!(count, 1, "Should deduplicate repeated betas, got: {}", result);
+    }
+
+    #[test]
+    fn test_from_headers_missing_both() {
+        let headers = HeaderMap::new();
+        let ch = ClientHeaders::from_headers(&headers);
+        assert!(ch.anthropic_beta.is_none());
+        assert!(ch.anthropic_version.is_none());
+    }
+
+    #[test]
+    fn test_from_headers_with_other_headers() {
+        // Other headers (like authorization) should be ignored
+        let mut headers = HeaderMap::new();
+        headers.insert(
+            axum::http::HeaderName::from_static("authorization"),
+            axum::http::HeaderValue::from_static("Bearer sk-test"),
+        );
+        headers.insert(
+            axum::http::HeaderName::from_static("anthropic-beta"),
+            axum::http::HeaderValue::from_static("test-beta"),
+        );
+        let ch = ClientHeaders::from_headers(&headers);
+        assert_eq!(ch.anthropic_beta.as_deref(), Some("test-beta"));
+        assert!(ch.anthropic_version.is_none());
+    }
+
+    #[test]
+    fn test_version_header_missing_uses_default() {
+        let ch = ClientHeaders { anthropic_beta: None, anthropic_version: None };
+        assert_eq!(ch.resolve_anthropic_version(), "2023-06-01");
+    }
+}

--- a/src/proxy/mod.rs
+++ b/src/proxy/mod.rs
@@ -13,6 +13,7 @@ pub mod classify;
 pub mod concurrency;
 pub mod discovery;
 pub mod error_types;
+pub mod headers;
 pub mod non_streaming;
 pub mod overflow_tracker;
 pub mod rate_limit;
@@ -20,7 +21,7 @@ pub mod retry;
 pub mod streaming;
 pub mod token_scaling;
 
-use axum::{response::Response, Extension, Json};
+use axum::{http::HeaderMap, response::Response, Extension, Json};
 use metrics::{counter, gauge, histogram};
 use reqwest::Client;
 
@@ -171,6 +172,7 @@ pub(crate) fn resolve_cc_context_window(model_id: &str, config: &Config) -> u32 
     token_scaling::resolve_effective_cc_context_window(raw, model_id)
 }
 
+#[allow(clippy::too_many_arguments)] // Axum extractors + HeaderMap for Issue #35
 pub async fn proxy_handler(
     Extension(shared_config): Extension<SharedConfig>,
     Extension(client): Extension<Client>,
@@ -178,6 +180,7 @@ pub async fn proxy_handler(
     Extension(model_cache): Extension<ModelCache>,
     Extension(model_semaphores): Extension<ModelSemaphores>,
     Extension(calibration): Extension<tokenizer::CalibrationFactors>,
+    headers: HeaderMap, // Issue #35 F4: Extract client headers for forwarding
     Json(req): Json<anthropic::AnthropicRequest>,
 ) -> ProxyResult<Response> {
     // S3: Track active connections
@@ -203,6 +206,21 @@ pub async fn proxy_handler(
     // v4.1: ArcSwap provides lock-free reads, no poisoning possible
     let config = shared_config.load_full();
 
+    // Issue #35 F4: Extract client headers for Anthropic header forwarding
+    let client_headers = crate::proxy::headers::ClientHeaders::from_headers(&headers);
+    if client_headers.anthropic_beta.is_some() {
+        tracing::debug!(
+            "📥 Client anthropic-beta: {}",
+            client_headers.anthropic_beta.as_deref().unwrap_or("")
+        );
+    }
+    if client_headers.anthropic_version.is_some() {
+        tracing::debug!(
+            "📥 Client anthropic-version: {}",
+            client_headers.anthropic_version.as_deref().unwrap_or("")
+        );
+    }
+
     tracing::info!("Received request: model={} streaming={}", req.model, is_streaming);
 
     // v8.0: Log CC thinking/effort params for forensic investigation
@@ -225,7 +243,10 @@ pub async fn proxy_handler(
         );
     }
 
-    let transform_result = transform::anthropic_to_openai(req.clone(), &config)?;
+    // Issue #35 F9: Pre-resolve upstream_name for conditional chat_template_kwargs
+    let (_, upstream_name_pre) = transform::resolve_model_and_upstream(&req.model, true, &config);
+    let transform_result =
+        transform::anthropic_to_openai(req.clone(), &config, &upstream_name_pre)?;
     let mut openai_req = transform_result.request;
     let upstream_name = transform_result.upstream_name;
     // PHASE 3.5: Cache markers available for cache integration (currently unused)
@@ -279,6 +300,7 @@ pub async fn proxy_handler(
             cc_context_window, // Issue #28: resolved dynamically
             &circuit_breaker,
             crate::SHUTDOWN_TOKEN.clone(), // NEW: pass cancellation token for graceful shutdown
+            client_headers.clone(), // Issue #35 F5: forward client headers for Anthropic upstreams
         )
         .await
     } else {
@@ -290,8 +312,9 @@ pub async fn proxy_handler(
             &upstream_name,
             model_semaphores,
             &circuit_breaker,
-            context_limit,     // FIX 6: pass context_limit for token scaling
-            cc_context_window, // Issue #28: resolved dynamically
+            context_limit,          // FIX 6: pass context_limit for token scaling
+            cc_context_window,      // Issue #28: resolved dynamically
+            client_headers.clone(), // Issue #35 F5: forward client headers for Anthropic upstreams
         )
         .await
     };

--- a/src/proxy/non_streaming.rs
+++ b/src/proxy/non_streaming.rs
@@ -37,6 +37,7 @@ pub(crate) async fn handle_non_streaming(
     circuit_breaker: &crate::proxy::concurrency::CircuitBreaker,
     context_limit: u32,     // FIX 6: for token_scaling
     cc_context_window: u32, // Issue #28: resolved dynamically
+    client_headers: crate::proxy::headers::ClientHeaders,
 ) -> ProxyResult<axum::response::Response> {
     // ╔═══════════════════════════════════════════╗
     // ║ Concurrency Shield: acquire model permit ║
@@ -69,6 +70,7 @@ pub(crate) async fn handle_non_streaming(
             &mut current_openai_req,
             upstream_name,
             circuit_breaker,
+            &client_headers,
         )
         .await?;
 
@@ -176,7 +178,8 @@ pub(crate) async fn handle_non_streaming(
 
                 let mut rebuilt_req = original_req.clone();
                 rebuilt_req.messages = current_messages.clone();
-                let transform_result = transform::anthropic_to_openai(rebuilt_req, &config)?;
+                let transform_result =
+                    transform::anthropic_to_openai(rebuilt_req, &config, upstream_name)?;
                 current_openai_req = transform_result.request;
 
                 tracing::info!(

--- a/src/proxy/retry.rs
+++ b/src/proxy/retry.rs
@@ -13,7 +13,10 @@ use crate::proxy::error_types::parse_upstream_error;
 use crate::proxy::overflow_tracker::OverflowLoopTracker;
 
 // v0.11.0: Stream stability constants (CR-01, CR-02)
-pub(crate) const CHUNK_TIMEOUT_SECS: u64 = 120; // Max seconds to wait for next SSE chunk from NIM
+// CR3-fix: Configurable via CHUNK_TIMEOUT_SECS env var (default 120s)
+pub(crate) fn chunk_timeout_secs() -> u64 {
+    std::env::var("CHUNK_TIMEOUT_SECS").ok().and_then(|v| v.parse().ok()).unwrap_or(120)
+}
 pub(crate) const MAX_SSE_BUFFER: usize = 10 * 1024 * 1024; // 10MB safety limit for SSE buffer
 
 /// Resilient send for non-streaming: returns parsed OpenAI response.
@@ -264,7 +267,11 @@ pub(crate) async fn resilient_send_raw(
         let mut req_builder = client
             .post(config.get_upstream_url(upstream_name))
             .json(&*openai_req)
-            .timeout(Duration::from_secs(300)); // P0: was 900s — must be < CC's API_TIMEOUT_MS (600s)
+            // CR1-fix: No per-request timeout for streaming.
+            // Protection: read_timeout(120s) on client + CHUNK_TIMEOUT in streaming.rs
+            // CR2-fix: Force HTTP/1.1 — NIM sends HTTP/2 GOAWAY that kills long streams.
+            // HTTP/1.1 uses a dedicated TCP connection with no multiplexing interference.
+            .version(reqwest::Version::HTTP_11);
 
         if let Some(api_key) = &config.get_upstream_key(upstream_name) {
             req_builder = req_builder.header("Authorization", format!("Bearer {}", api_key));

--- a/src/proxy/retry.rs
+++ b/src/proxy/retry.rs
@@ -22,12 +22,14 @@ pub(crate) const MAX_SSE_BUFFER: usize = 10 * 1024 * 1024; // 10MB safety limit 
 /// Resilient send for non-streaming: returns parsed OpenAI response.
 /// Auto-retries on 429 (rate limit) with exponential backoff.
 /// Auto-clamps max_tokens on 400 (too large) and retries.
+#[allow(clippy::too_many_arguments)]
 pub(crate) async fn resilient_send(
     client: &Client,
     config: &Config,
     openai_req: &mut openai::OpenAIRequest,
     upstream_name: &str,
     circuit_breaker: &crate::proxy::concurrency::CircuitBreaker,
+    client_headers: &crate::proxy::headers::ClientHeaders,
 ) -> ProxyResult<openai::OpenAIResponse> {
     let mut attempt: u32 = 0;
 
@@ -60,9 +62,24 @@ pub(crate) async fn resilient_send(
             req_builder = req_builder.header("Authorization", format!("Bearer {}", api_key));
         }
 
-        // v0.13.0: Only send anthropic-beta to Anthropic endpoints
+        // Issue #35: Forward anthropic-beta + anthropic-version to Anthropic upstreams
         if config.get_upstream_type(upstream_name) == UpstreamType::Anthropic {
-            req_builder = req_builder.header("anthropic-beta", "prompt-caching-2024-06-01");
+            // Bug B: Forward merged betas (client + proxy minimum, deduplicated)
+            // Bug C: Auto-resolved — no more hardcoded outdated beta value
+            // User Decision Q1 (Option C): merge client + proxy betas
+            // User Decision Q2 (Option B): always inject minimum set
+            let beta = client_headers.resolve_anthropic_beta();
+            let version = client_headers.resolve_anthropic_version();
+            tracing::debug!(
+                "📤 Forwarding to Anthropic upstream '{}': beta={}, version={}",
+                upstream_name,
+                beta,
+                version
+            );
+            req_builder = req_builder.header("anthropic-beta", &beta);
+            // Bug D: Forward anthropic-version with fallback
+            // User Decision Q5 (Option A): forward with default
+            req_builder = req_builder.header("anthropic-version", version);
         }
 
         let response = req_builder.send().await?;
@@ -236,12 +253,14 @@ pub(crate) async fn resilient_send(
 
 /// Resilient send for streaming: returns raw reqwest::Response (not parsed).
 /// Same retry logic as resilient_send but returns the response for streaming.
+#[allow(clippy::too_many_arguments)]
 pub(crate) async fn resilient_send_raw(
     client: &Client,
     config: &Config,
     openai_req: &mut openai::OpenAIRequest,
     upstream_name: &str,
     circuit_breaker: &crate::proxy::concurrency::CircuitBreaker,
+    client_headers: &crate::proxy::headers::ClientHeaders,
 ) -> ProxyResult<reqwest::Response> {
     let mut attempt: u32 = 0;
 
@@ -277,9 +296,18 @@ pub(crate) async fn resilient_send_raw(
             req_builder = req_builder.header("Authorization", format!("Bearer {}", api_key));
         }
 
-        // v0.13.0: Only send anthropic-beta to Anthropic endpoints
+        // Issue #35: Forward anthropic-beta + anthropic-version to Anthropic upstreams
         if config.get_upstream_type(upstream_name) == UpstreamType::Anthropic {
-            req_builder = req_builder.header("anthropic-beta", "prompt-caching-2024-06-01");
+            let beta = client_headers.resolve_anthropic_beta();
+            let version = client_headers.resolve_anthropic_version();
+            tracing::debug!(
+                "📤 [stream] Forwarding to Anthropic upstream '{}': beta={}, version={}",
+                upstream_name,
+                beta,
+                version
+            );
+            req_builder = req_builder.header("anthropic-beta", &beta);
+            req_builder = req_builder.header("anthropic-version", version);
         }
 
         let response = req_builder.send().await?;
@@ -453,5 +481,53 @@ pub(crate) async fn resilient_send_raw(
                 )));
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod anthropic_header_tests {
+    use crate::proxy::headers::ClientHeaders;
+
+    #[test]
+    fn test_anthropic_headers_sent_to_anthropic_upstream() {
+        // Verify that when upstream type is Anthropic, headers would be set
+        let ch = ClientHeaders {
+            anthropic_beta: Some("interleaved-thinking-2025-05-14".into()),
+            anthropic_version: Some("2024-10-22".into()),
+        };
+        let beta = ch.resolve_anthropic_beta();
+        let version = ch.resolve_anthropic_version();
+
+        // Beta should include proxy minimum + client betas
+        assert!(beta.contains("prompt-caching-scope-2026-01-05"));
+        assert!(beta.contains("interleaved-thinking-2025-05-14"));
+
+        // Version should be forwarded
+        assert_eq!(version, "2024-10-22");
+    }
+
+    #[test]
+    fn test_anthropic_headers_default_version() {
+        // When client doesn't send anthropic-version, default is used
+        let ch = ClientHeaders { anthropic_beta: None, anthropic_version: None };
+
+        assert_eq!(ch.resolve_anthropic_version(), "2023-06-01");
+        assert_eq!(ch.resolve_anthropic_beta(), "prompt-caching-scope-2026-01-05");
+    }
+
+    #[test]
+    fn test_beta_merge_with_per_route_type() {
+        // When global=NIM but bigmodel=Anthropic, only bigmodel gets betas
+        // This is tested by get_upstream_type() — if it returns Anthropic,
+        // the headers code runs. If it returns NIM, the headers code doesn't run.
+        // Here we verify the header resolution logic itself.
+        let ch = ClientHeaders {
+            anthropic_beta: Some("compact-2026-01-12".into()),
+            anthropic_version: None,
+        };
+        let beta = ch.resolve_anthropic_beta();
+
+        assert!(beta.contains("prompt-caching-scope-2026-01-05"));
+        assert!(beta.contains("compact-2026-01-12"));
     }
 }

--- a/src/proxy/streaming.rs
+++ b/src/proxy/streaming.rs
@@ -39,6 +39,7 @@ pub(crate) async fn handle_streaming(
     cc_context_window: u32, // Issue #28: resolved dynamically
     _circuit_breaker: &crate::proxy::concurrency::CircuitBreaker,
     shutdown_token: CancellationToken,
+    client_headers: crate::proxy::headers::ClientHeaders,
 ) -> ProxyResult<Response> {
     let permit = acquire_model_permit(
         &model_semaphores,
@@ -64,9 +65,15 @@ pub(crate) async fn handle_streaming(
         nim_model_name
     );
 
-    let response =
-        resilient_send_raw(&client, &config, &mut mutable_req, upstream_name, _circuit_breaker)
-            .await?;
+    let response = resilient_send_raw(
+        &client,
+        &config,
+        &mut mutable_req,
+        upstream_name,
+        _circuit_breaker,
+        &client_headers,
+    )
+    .await?;
 
     let stream = response.bytes_stream();
     let original_model_owned = original_model.to_string();

--- a/src/proxy/streaming.rs
+++ b/src/proxy/streaming.rs
@@ -16,7 +16,7 @@ use crate::config::Config;
 use crate::error::ProxyResult;
 use crate::models::{anthropic, openai};
 use crate::proxy::concurrency::{acquire_model_permit, ModelSemaphores};
-use crate::proxy::retry::{resilient_send_raw, CHUNK_TIMEOUT_SECS, MAX_SSE_BUFFER};
+use crate::proxy::retry::{chunk_timeout_secs, resilient_send_raw, MAX_SSE_BUFFER};
 use crate::proxy::token_scaling::scale_token_usage;
 use crate::tokenizer;
 use crate::transform;
@@ -144,7 +144,8 @@ pub(crate) fn create_sse_stream(
     let mut last_keepalive = std::time::Instant::now();
     // Use min of KEEPALIVE_INTERVAL and CHUNK_TIMEOUT for the select timeout
     // This allows us to emit keep-alive even when CHUNK_TIMEOUT is 120s
-    let keepalive_check_interval = Duration::from_secs(KEEPALIVE_INTERVAL_SECS.min(CHUNK_TIMEOUT_SECS));
+    let chunk_timeout = chunk_timeout_secs();
+    let keepalive_check_interval = Duration::from_secs(KEEPALIVE_INTERVAL_SECS.min(chunk_timeout));
     let mut consecutive_keepalives: u32 = 0;
 
     loop {
@@ -165,9 +166,9 @@ pub(crate) fn create_sse_stream(
                             last_keepalive = std::time::Instant::now();
                             consecutive_keepalives += 1;
                             // If too many consecutive keepalives, the upstream is truly dead
-                            let max_consecutive = (CHUNK_TIMEOUT_SECS / KEEPALIVE_INTERVAL_SECS).max(1);
+                            let max_consecutive = (chunk_timeout / KEEPALIVE_INTERVAL_SECS).max(1);
                             if consecutive_keepalives >= max_consecutive as u32 {
-                                tracing::error!("⏰ Stream chunk timeout after {}s — emitting error event", CHUNK_TIMEOUT_SECS);
+                                tracing::error!("⏰ Stream chunk timeout after {}s — emitting error event", chunk_timeout);
                                 // CR7: Emit error event unconditionally — client needs it even before message_start
                                 let error_event = json!({
                                     "type": "error",
@@ -175,7 +176,7 @@ pub(crate) fn create_sse_stream(
                                         "type": "api_error",
                                         "message": format!(
                                             "Stream timeout: upstream stopped responding after {}s. The response may be incomplete.",
-                                            CHUNK_TIMEOUT_SECS
+                                            chunk_timeout
                                         )
                                     }
                                 });
@@ -636,17 +637,37 @@ pub(crate) fn create_sse_stream(
                     }
                 }
                 Err(e) => {
-                    tracing::error!("Stream error: {}", e);
+                    // CR4-fix: Diagnose specific error type for forensics
+                    let err_detail = format!(
+                        "timeout={}, connect={}, decode={}, body={}, status={:?}",
+                        e.is_timeout(), e.is_connect(), e.is_decode(), e.is_body(), e.status()
+                    );
+                    tracing::error!("Stream error: {} [{}]", e, err_detail);
                     let error_event = json!({
                         "type": "error",
                         "error": {
                             "type": "api_error",
-                            "message": format!("Stream error: {}", e)
+                            "message": format!(
+                                "Stream error: {}. This is a transient upstream error — retry should succeed.",
+                                e
+                            )
                         }
                     });
                     let sse_data = format!("event: error\ndata: {}\n\n",
                         serde_json::to_string(&error_event).unwrap_or_default());
                     yield Ok(Bytes::from(sse_data));
+
+                    // CR4-fix: Close stream cleanly so CC doesn't hang
+                    if has_sent_message_start {
+                        if current_block_type.is_some() {
+                            let stop_block = json!({"type": "content_block_stop", "index": content_index});
+                            yield Ok(Bytes::from(format!("event: content_block_stop\ndata: {}\n\n",
+                                serde_json::to_string(&stop_block).unwrap_or_default())));
+                        }
+                        let stop_event = json!({"type": "message_stop"});
+                        yield Ok(Bytes::from(format!("event: message_stop\ndata: {}\n\n",
+                            serde_json::to_string(&stop_event).unwrap_or_default())));
+                    }
                     break;
                 }
             }

--- a/src/transform.rs
+++ b/src/transform.rs
@@ -1,4 +1,4 @@
-use crate::config::Config;
+use crate::config::{Config, UpstreamType};
 use crate::error::{ProxyError, ProxyResult};
 use crate::models::{anthropic, openai};
 use crate::prompt_cache::{CacheLocation, PromptCache};
@@ -30,7 +30,7 @@ pub struct TransformResult {
 }
 
 /// Resolve model name and upstream from model map or config defaults
-fn resolve_model_and_upstream(
+pub(crate) fn resolve_model_and_upstream(
     req_model: &str,
     has_thinking: bool,
     config: &Config,
@@ -59,6 +59,7 @@ fn resolve_model_and_upstream(
 pub fn anthropic_to_openai(
     req: anthropic::AnthropicRequest,
     config: &Config,
+    upstream_name: &str, // Issue #35 F9: for conditional chat_template_kwargs
 ) -> ProxyResult<TransformResult> {
     // v5.0: Force thinking (effort max) for ALL models globally.
     // CC defaults to effort=medium which sends thinking.type="adaptive".
@@ -71,7 +72,7 @@ pub fn anthropic_to_openai(
     let mut cache_markers: Vec<CacheMarker> = Vec::new();
 
     // Resolve model AND upstream via model map or config
-    let (model, upstream_name) = resolve_model_and_upstream(&req.model, has_thinking, config);
+    let (model, _resolved_upstream) = resolve_model_and_upstream(&req.model, has_thinking, config);
 
     // Convert messages
     let mut openai_messages = Vec::new();
@@ -220,7 +221,11 @@ pub fn anthropic_to_openai(
             },
             tools,
             tool_choice: None,
-            chat_template_kwargs: if has_thinking {
+            // Issue #35 Bug E: chat_template_kwargs only valid for NIM upstreams.
+            // Anthropic/OpenAI/OpenRouter don't recognize this field.
+            chat_template_kwargs: if has_thinking
+                && config.get_upstream_type(upstream_name) == UpstreamType::NIM
+            {
                 Some(json!({
                     "enable_thinking": true,
                     "clear_thinking": false
@@ -229,7 +234,7 @@ pub fn anthropic_to_openai(
                 None
             },
         },
-        upstream_name,
+        upstream_name: upstream_name.to_string(),
         cache_markers,
     })
 }

--- a/src/transform_test.rs
+++ b/src/transform_test.rs
@@ -47,6 +47,15 @@ mod tests {
                 target_model: "z-ai/glm5".to_string(),
             },
         );
+        // Insert bigmodel upstream entry so get_upstream_type can resolve it
+        config.upstreams.insert(
+            "bigmodel".to_string(),
+            crate::config::UpstreamConfig {
+                base_url: "http://bigmodel:11434".to_string(),
+                api_key: None,
+                upstream_type: None, // inherits global type by default
+            },
+        );
         config
     }
 
@@ -80,7 +89,8 @@ mod tests {
         };
 
         let config = test_config();
-        let result = anthropic_to_openai(req, &config).expect("Transform should succeed");
+        let result =
+            anthropic_to_openai(req, &config, "default").expect("Transform should succeed");
 
         // Verify cache_markers has length 1 from system prompt
         assert_eq!(
@@ -135,7 +145,8 @@ mod tests {
         };
 
         let config = test_config();
-        let result = anthropic_to_openai(req, &config).expect("Transform should succeed");
+        let result =
+            anthropic_to_openai(req, &config, "default").expect("Transform should succeed");
 
         // Debug output
         eprintln!("DEBUG: cache_markers.len() = {}", result.cache_markers.len());
@@ -191,7 +202,8 @@ mod tests {
         };
 
         let config = test_config();
-        let result = anthropic_to_openai(req, &config).expect("Transform should succeed");
+        let result =
+            anthropic_to_openai(req, &config, "default").expect("Transform should succeed");
 
         // Verify cache_markers is empty
         assert!(
@@ -242,7 +254,8 @@ mod tests {
         };
 
         let config = test_config();
-        let result = anthropic_to_openai(req, &config).expect("Transform should succeed");
+        let result =
+            anthropic_to_openai(req, &config, "default").expect("Transform should succeed");
 
         // Verify multiple markers are extracted from message content blocks
         // (system prompt markers not yet implemented)
@@ -284,7 +297,8 @@ mod tests {
             extra: json!({}),
         };
 
-        let result = anthropic_to_openai(req, &config).expect("Transform should succeed");
+        let result =
+            anthropic_to_openai(req, &config, "bigmodel").expect("Transform should succeed");
 
         // Verify upstream_name is set to "bigmodel"
         assert_eq!(
@@ -318,7 +332,8 @@ mod tests {
         };
 
         let config = test_config();
-        let result = anthropic_to_openai(req, &config).expect("Transform should succeed");
+        let result =
+            anthropic_to_openai(req, &config, "default").expect("Transform should succeed");
 
         // Verify the request field is a properly constructed OpenAIRequest
         assert!(!result.request.model.is_empty(), "Request model should not be empty");
@@ -512,5 +527,157 @@ mod tests {
         // Should NOT be scaled - tokens should pass through as-is
         assert_eq!(result.usage.input_tokens, 100000);
         assert_eq!(result.usage.output_tokens, 4000);
+    }
+
+    // =========================================================================
+    // Issue #35 F9: Conditional chat_template_kwargs gating tests
+    // =========================================================================
+
+    #[test]
+    fn test_chat_template_kwargs_sent_to_nim() {
+        // With default NIM type, chat_template_kwargs should be included
+        let message = Message {
+            role: "user".to_string(),
+            content: MessageContent::Text("Hello".to_string()),
+            extra: json!({}),
+        };
+
+        let req = AnthropicRequest {
+            model: "claude-sonnet-4-6".to_string(),
+            messages: vec![message],
+            max_tokens: 4096,
+            temperature: None,
+            top_p: None,
+            top_k: None,
+            stop_sequences: None,
+            stream: None,
+            tools: None,
+            system: None,
+            metadata: None,
+            extra: json!({}),
+        };
+
+        let config = test_config(); // global NIM
+        let result =
+            anthropic_to_openai(req, &config, "default").expect("Transform should succeed");
+        assert!(
+            result.request.chat_template_kwargs.is_some(),
+            "chat_template_kwargs should be present for NIM upstream"
+        );
+    }
+
+    #[test]
+    fn test_chat_template_kwargs_not_sent_to_anthropic() {
+        // With Anthropic type, chat_template_kwargs should NOT be included
+        let mut config = test_config();
+        config.upstream_type = crate::config::UpstreamType::Anthropic;
+
+        let message = Message {
+            role: "user".to_string(),
+            content: MessageContent::Text("Hello".to_string()),
+            extra: json!({}),
+        };
+
+        let req = AnthropicRequest {
+            model: "claude-sonnet-4-6".to_string(),
+            messages: vec![message],
+            max_tokens: 4096,
+            temperature: None,
+            top_p: None,
+            top_k: None,
+            stop_sequences: None,
+            stream: None,
+            tools: None,
+            system: None,
+            metadata: None,
+            extra: json!({}),
+        };
+
+        let result =
+            anthropic_to_openai(req, &config, "default").expect("Transform should succeed");
+        assert!(
+            result.request.chat_template_kwargs.is_none(),
+            "chat_template_kwargs should NOT be present for Anthropic upstream"
+        );
+    }
+
+    #[test]
+    fn test_chat_template_kwargs_not_sent_to_openai() {
+        // With OpenAI type, chat_template_kwargs should NOT be included
+        let mut config = test_config();
+        config.upstream_type = crate::config::UpstreamType::OpenAI;
+
+        let message = Message {
+            role: "user".to_string(),
+            content: MessageContent::Text("Hello".to_string()),
+            extra: json!({}),
+        };
+
+        let req = AnthropicRequest {
+            model: "claude-sonnet-4-6".to_string(),
+            messages: vec![message],
+            max_tokens: 4096,
+            temperature: None,
+            top_p: None,
+            top_k: None,
+            stop_sequences: None,
+            stream: None,
+            tools: None,
+            system: None,
+            metadata: None,
+            extra: json!({}),
+        };
+
+        let result =
+            anthropic_to_openai(req, &config, "default").expect("Transform should succeed");
+        assert!(
+            result.request.chat_template_kwargs.is_none(),
+            "chat_template_kwargs should NOT be present for OpenAI upstream"
+        );
+    }
+
+    // =========================================================================
+    // Issue #35 F10: Edge case test for chat_template_kwargs per-route
+    // =========================================================================
+
+    #[test]
+    fn test_chat_template_kwargs_per_route_nim_default_anthropic_bigmodel() {
+        // Global=NIM but bigmodel=Anthropic → request to bigmodel should NOT have chat_template_kwargs
+        let mut config = test_config_with_model_map();
+        // Set bigmodel upstream to Anthropic type
+        config
+            .upstreams
+            .get_mut("bigmodel")
+            .expect("bigmodel upstream should exist")
+            .upstream_type = Some(crate::config::UpstreamType::Anthropic);
+        config.upstream_type = crate::config::UpstreamType::NIM; // global NIM
+
+        let message = Message {
+            role: "user".to_string(),
+            content: MessageContent::Text("Hello".to_string()),
+            extra: json!({}),
+        };
+
+        let req = AnthropicRequest {
+            model: "claude-opus-4-6".to_string(), // maps to bigmodel
+            messages: vec![message],
+            max_tokens: 4096,
+            temperature: None,
+            top_p: None,
+            top_k: None,
+            stop_sequences: None,
+            stream: None,
+            tools: None,
+            system: None,
+            metadata: None,
+            extra: json!({}),
+        };
+
+        let result =
+            anthropic_to_openai(req, &config, "bigmodel").expect("Transform should succeed");
+        assert!(
+            result.request.chat_template_kwargs.is_none(),
+            "chat_template_kwargs should NOT be present when upstream is Anthropic even if global is NIM"
+        );
     }
 }


### PR DESCRIPTION
## Summary

- **Bug A**: `get_upstream_type()` ignored `upstream_name` param — now does real per-upstream lookup with global fallback
- **Bug B**: Hardcoded `anthropic-beta` header — now extracted from client headers, merged with `PROXY_MINIMUM_BETAS`, deduplicated
- **Bug C**: Outdated beta version `prompt-caching-2024-06-01` → replaced with `prompt-caching-scope-2026-01-05`
- **Bug D**: Missing `anthropic-version` header — now forwarded from client with fallback `2023-06-01`
- **Bug E**: Unconditional `chat_template_kwargs` — now only sent to NIM upstreams (Anthropic/OpenAI/OpenRouter handle thinking natively)
- **Bug F**: No startup validation — warnings for model_map routes without matching upstream config

## Key Changes

| File | Change |
|------|--------|
| `src/proxy/headers.rs` | **NEW** — `ClientHeaders` struct for header extraction/resolution |
| `src/config.rs` | Per-upstream `upstream_type` field, `UPSTREAM_<NAME>_TYPE` env var, generalized type scan, startup validation |
| `src/config_cmd.rs` | Show per-upstream type and `[type=...]` in model map entries |
| `src/proxy/mod.rs` | Extract `ClientHeaders` from request, pass through pipeline |
| `src/proxy/retry.rs` | Dynamic `anthropic-beta` + `anthropic-version` headers (conditional on Anthropic upstream) |
| `src/proxy/streaming.rs` | Thread `ClientHeaders` to `resilient_send_raw()` |
| `src/proxy/non_streaming.rs` | Thread `ClientHeaders` to `resilient_send()` |
| `src/transform.rs` | Conditional `chat_template_kwargs` (NIM only), `upstream_name` param |
| `src/transform_test.rs` | 4 new tests for conditional behavior + per-route edge case |
| `CLAUDE.md` | New env var docs, `headers.rs` module entry, updated design conventions |

## Design Decisions (from user consultation)

- **Q1 (Beta merge)**: Option C — Combine client betas + `PROXY_MINIMUM_BETAS`, deduplicate
- **Q2 (Default beta)**: Option B — Always send at least `prompt-caching-scope-2026-01-05` to Anthropic upstreams
- **Q3 (Per-route type)**: Option A — Field in `UpstreamConfig`, NOT `ModelRoute`
- **Q4 (Env var convention)**: Option A — `UPSTREAM_<NAME>_TYPE` consistent with existing pattern
- **Q5 (anthropic-version)**: Option A — Forward from client with fallback `2023-06-01`

## Test Plan

- [x] 209 tests passing (174 → +35 new)
- [x] `cargo clippy -- -D warnings` clean
- [x] `cargo fmt --check` clean
- [x] Release build OK (7.9 MB)
- [x] `cargo audit` clean
- [ ] Manual test with multi-upstream config (Anthropic + NIM)
- [ ] Verify `anthropic-beta` header present in Anthropic upstream requests
- [ ] Verify `anthropic-version` header forwarded from client
- [ ] Verify `chat_template_kwargs` absent for non-NIM upstreams
- [ ] Verify startup warnings for misconfigured model_map routes

Closes #35

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Per-upstream type overrides (env/runtime) and config display of upstream types
  * Client Anthropic header support: forwarding/merging of anthopic-beta and anthropic-version
  * Dynamic chunk timeout (env-driven) for streaming/read timeouts
  * chat_template_kwargs now applied only for NIM upstreams

* **Bug Fixes**
  * Improved streaming error handling, keep-alive/timeouts, and retry behavior

* **Tests**
  * New unit/integration tests covering header resolution, typing, and transform behavior

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/enerBydev/nexus-ai-gateway/pull/82?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->