### PR TITLE
fix: Global fix for Issues #63, #74, #80, #60 — 11 interconnected bugs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # NEXUS-AI-Gateway
 
-![NEXUS Instances](https://img.shields.io/endpoint?url=https://nexus-beacon-receiver.enerby212.workers.dev/v1/stats/shield)
 
 API proxy translating Anthropic Messages API to OpenAI-compatible format.
 
+![NEXUS-Instances](https://img.shields.io/endpoint?url=https://nexus-beacon-receiver.enerby212.workers.dev/v1/stats/shield)
 [![CI](https://img.shields.io/github/actions/workflow/status/enerBydev/NEXUS-AI-Gateway/ci.yml?branch=main)](https://github.com/enerBydev/NEXUS-AI-Gateway/actions)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 [![Rust](https://img.shields.io/badge/rust-1.85+-orange.svg)](https://www.rust-lang.org)

--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -142,6 +142,16 @@ tasks:
     cmds:
       - cargo audit
 
+  sanitize-unicode:
+    desc: "Replace Unicode with ASCII in Rust source files"
+    cmds:
+      - bash scripts/sanitize-unicode.sh
+
+  sanitize-unicode-check:
+    desc: "Verify no Unicode in source files (CI mode)"
+    cmds:
+      - bash scripts/sanitize-unicode.sh --check
+
   update:
     desc: Update dependencies
     cmds:

--- a/scripts/hooks/pre-commit
+++ b/scripts/hooks/pre-commit
@@ -21,6 +21,18 @@ if [ -n "$LARGE_FILES" ]; then
     echo ""
 fi
 
+# Check for Unicode in Rust files (Issue #88: C1/C2 Edit tool failures)
+if git diff --cached --name-only -- '*.rs' | head -1 | grep -q .; then
+    echo " Running Unicode check..."
+    if ! bash scripts/sanitize-unicode.sh --check 2>/dev/null; then
+        echo ""
+        echo "❌ Unicode characters detected in source files!"
+        echo " Run: bash scripts/sanitize-unicode.sh"
+        exit 1
+    fi
+    echo " ✅ Unicode check passed"
+fi
+
 # Check if there are Rust files staged
 RUST_FILES=$(git diff --cached --name-only -- '*.rs')
 if [ -n "$RUST_FILES" ]; then

--- a/scripts/sanitize-unicode.sh
+++ b/scripts/sanitize-unicode.sh
@@ -66,7 +66,7 @@ while IFS= read -r -d '' file; do
     if [ "$FILE_HAD_CHANGE" -eq 1 ] && [ "$CHECK_ONLY" = false ] && [ "$DRY_RUN" = false ]; then
         CHANGED=1
     fi
-done < <(find src -name "*.rs" -print0)
+done < <(git ls-files -z '*.rs')
 
 if [ "$CHECK_ONLY" = true ]; then
     if [ "$CHANGED" -eq 1 ]; then

--- a/scripts/sanitize-unicode.sh
+++ b/scripts/sanitize-unicode.sh
@@ -1,0 +1,94 @@
+#!/bin/bash
+# scripts/sanitize-unicode.sh
+# Replaces Unicode characters in Rust source files with ASCII equivalents.
+# This eliminates Edit tool failures caused by CC Unicode normalization bugs (C1/C2).
+#
+# Usage:
+#   ./scripts/sanitize-unicode.sh           # Replace in-place
+#   ./scripts/sanitize-unicode.sh --dry-run # Preview changes only
+#   ./scripts/sanitize-unicode.sh --check   # Exit 1 if any Unicode found (CI mode)
+
+set -euo pipefail
+
+DRY_RUN=false
+CHECK_ONLY=false
+
+for arg in "$@"; do
+    case "$arg" in
+        --dry-run) DRY_RUN=true ;;
+        --check)   CHECK_ONLY=true ;;
+    esac
+done
+
+# Unicode -> ASCII mapping table
+# Each entry: "unicode_char" "ascii_replacement"
+declare -A UNICODE_MAP=(
+    ["→"]="->"
+    ["⏱️"]="[TIMEOUT]"
+    ["⚠️"]="[WARN]"
+    ["✓"]="[OK]"
+    ["✗"]="[FAIL]"
+    ["🔍"]="[SCAN]"
+    ["📐"]="[CALIB]"
+    ["🛡️"]="[GUARD]"
+    ["📋"]="[TODO]"
+    ["🚀"]="[LAUNCH]"
+    ["📍"]="[PIN]"
+)
+
+CHANGED=0
+TOTAL_REPLACEMENTS=0
+
+# Find all .rs source files (exclude test-only files if needed)
+while IFS= read -r -d '' file; do
+    FILE_HAD_CHANGE=0
+    for unicode_char in "${!UNICODE_MAP[@]}"; do
+        ascii_replacement="${UNICODE_MAP[$unicode_char]}"
+
+        if grep -q "$unicode_char" "$file" 2>/dev/null; then
+            count=$(grep -o "$unicode_char" "$file" 2>/dev/null | wc -l || echo 0)
+            TOTAL_REPLACEMENTS=$((TOTAL_REPLACEMENTS + count))
+
+            if [ "$CHECK_ONLY" = true ]; then
+                echo "CHECK FAIL: $file contains '$unicode_char' ($count occurrences)"
+                CHANGED=1
+            elif [ "$DRY_RUN" = true ]; then
+                echo "WOULD REPLACE: $file '$unicode_char' -> '$ascii_replacement' ($count occurrences)"
+            else
+                # Escape special characters for sd
+                sd -- "$unicode_char" "$ascii_replacement" "$file"
+                echo "REPLACED: $file '$unicode_char' -> '$ascii_replacement' ($count occurrences)"
+                FILE_HAD_CHANGE=1
+            fi
+        fi
+    done
+
+    if [ "$FILE_HAD_CHANGE" -eq 1 ] && [ "$CHECK_ONLY" = false ] && [ "$DRY_RUN" = false ]; then
+        CHANGED=1
+    fi
+done < <(find src -name "*.rs" -print0)
+
+if [ "$CHECK_ONLY" = true ]; then
+    if [ "$CHANGED" -eq 1 ]; then
+        echo ""
+        echo "ERROR: Found Unicode characters in source files."
+        echo "Run: bash scripts/sanitize-unicode.sh"
+        exit 1
+    else
+        echo "OK: No Unicode characters found in source files."
+        exit 0
+    fi
+elif [ "$DRY_RUN" = true ]; then
+    echo ""
+    echo "Total replacements that would be made: $TOTAL_REPLACEMENTS"
+else
+    if [ "$CHANGED" -eq 1 ]; then
+        echo ""
+        echo "Total replacements made: $TOTAL_REPLACEMENTS"
+        echo "Run 'cargo fmt' to fix any formatting changes."
+    else
+        echo "OK: No Unicode characters found — source is clean."
+    fi
+fi
+
+exit 0

--- a/src/config.rs
+++ b/src/config.rs
@@ -218,7 +218,7 @@ impl Config {
             .unwrap_or(false);
 
         if base_url.ends_with("/v1") {
-            eprintln!("⚠️ WARNING: UPSTREAM_BASE_URL ends with '/v1'");
+            eprintln!("[WARN] WARNING: UPSTREAM_BASE_URL ends with '/v1'");
             eprintln!("   This will result in URLs like: {}/v1/chat/completions", base_url);
             eprintln!("   Consider removing '/v1' from UPSTREAM_BASE_URL");
             eprintln!("   Correct: https://openrouter.ai/api");
@@ -295,9 +295,14 @@ impl Config {
                 if let Some(type_val) = Self::get_from_map(data, &type_key) {
                     if let Ok(t) = type_val.parse::<UpstreamType>() {
                         upstream.upstream_type = Some(t);
-                        tracing::info!("📍 Upstream '{}' type set to {} via {}", name, t, type_key);
+                        tracing::info!(
+                            "[PIN] Upstream '{}' type set to {} via {}",
+                            name,
+                            t,
+                            type_key
+                        );
                     } else {
-                        tracing::warn!("⚠️ Invalid {}: '{}'", type_key, type_val);
+                        tracing::warn!("[WARN] Invalid {}: '{}'", type_key, type_val);
                     }
                 }
             }
@@ -316,7 +321,7 @@ impl Config {
                             target_model: target.to_string(),
                         },
                     );
-                    eprintln!(" 📍 Model map: {} → {}:{}", model_id, upstream, target);
+                    eprintln!(" [PIN] Model map: {} -> {}:{}", model_id, upstream, target);
                 }
             }
         }
@@ -450,13 +455,13 @@ impl Config {
                 if let Some(upstream) = upstreams.get(&route.upstream_name) {
                     if upstream.upstream_type.is_none() {
                         tracing::warn!(
-                        "⚠️ Model '{}' routes to upstream '{}' but no UPSTREAM_{}_TYPE configured — using global type '{}'",
+                        "[WARN] Model '{}' routes to upstream '{}' but no UPSTREAM_{}_TYPE configured — using global type '{}'",
                         model_id, route.upstream_name, route.upstream_name.to_uppercase(), upstream_type
                     );
                     }
                 } else {
                     tracing::warn!(
-                    "⚠️ Model '{}' routes to upstream '{}' which is not configured — will fall back to 'default'",
+                    "[WARN] Model '{}' routes to upstream '{}' which is not configured — will fall back to 'default'",
                     model_id, route.upstream_name
                 );
                 }
@@ -503,7 +508,7 @@ impl Config {
             if path.exists() && dotenvy::from_path(&path).is_ok() {
                 return Some(path);
             }
-            eprintln!("⚠️ WARNING: Custom config file not found: {}", path.display());
+            eprintln!("[WARN] WARNING: Custom config file not found: {}", path.display());
         }
 
         if let Ok(path) = dotenvy::dotenv() {
@@ -567,7 +572,7 @@ impl Config {
             env::var("VERBOSE").map(|v| v == "1" || v.to_lowercase() == "true").unwrap_or(false);
 
         if base_url.ends_with("/v1") {
-            eprintln!("⚠️ WARNING: UPSTREAM_BASE_URL ends with '/v1'");
+            eprintln!("[WARN] WARNING: UPSTREAM_BASE_URL ends with '/v1'");
             eprintln!("   This will result in URLs like: {}/v1/chat/completions", base_url);
             eprintln!("   Consider removing '/v1' from UPSTREAM_BASE_URL");
             eprintln!("   Correct: https://openrouter.ai/api");
@@ -642,9 +647,14 @@ impl Config {
                 if let Ok(type_val) = env::var(&type_key) {
                     if let Ok(t) = type_val.parse::<UpstreamType>() {
                         upstream.upstream_type = Some(t);
-                        tracing::info!("📍 Upstream '{}' type set to {} via {}", name, t, type_key);
+                        tracing::info!(
+                            "[PIN] Upstream '{}' type set to {} via {}",
+                            name,
+                            t,
+                            type_key
+                        );
                     } else {
-                        tracing::warn!("⚠️ Invalid {}: '{}'", type_key, type_val);
+                        tracing::warn!("[WARN] Invalid {}: '{}'", type_key, type_val);
                     }
                 }
             }
@@ -664,7 +674,7 @@ impl Config {
                             target_model: target.to_string(),
                         },
                     );
-                    eprintln!(" 📍 Model map: {} → {}:{}", model_id, upstream, target);
+                    eprintln!(" [PIN] Model map: {} -> {}:{}", model_id, upstream, target);
                 }
             }
         }
@@ -788,13 +798,13 @@ impl Config {
                 if let Some(upstream) = upstreams.get(&route.upstream_name) {
                     if upstream.upstream_type.is_none() {
                         tracing::warn!(
-                        "⚠️ Model '{}' routes to upstream '{}' but no UPSTREAM_{}_TYPE configured — using global type '{}'",
+                        "[WARN] Model '{}' routes to upstream '{}' but no UPSTREAM_{}_TYPE configured — using global type '{}'",
                         model_id, route.upstream_name, route.upstream_name.to_uppercase(), upstream_type
                     );
                     }
                 } else {
                     tracing::warn!(
-                    "⚠️ Model '{}' routes to upstream '{}' which is not configured — will fall back to 'default'",
+                    "[WARN] Model '{}' routes to upstream '{}' which is not configured — will fall back to 'default'",
                     model_id, route.upstream_name
                 );
                 }
@@ -1005,7 +1015,7 @@ mod tests {
         map.insert("MODEL_MAP_CLAUDE_OPUS_4_6".to_string(), "bigmodel:some-model".to_string());
         let config = Config::from_map(&map).unwrap();
         // Config should still load successfully (warnings, not errors)
-        // Env var MODEL_MAP_CLAUDE_OPUS_4_6 → key "claude-opus-4-6" (underscores→hyphens, lowercase)
+        // Env var MODEL_MAP_CLAUDE_OPUS_4_6 -> key "claude-opus-4-6" (underscores->hyphens, lowercase)
         assert!(config.model_map.contains_key("claude-opus-4-6"));
     }
 
@@ -1036,7 +1046,7 @@ mod tests {
 
     #[test]
     fn test_per_route_type_anthropic_with_global_nim() {
-        // Global=NIM, bigmodel=Anthropic → model_map routing to bigmodel uses type Anthropic
+        // Global=NIM, bigmodel=Anthropic -> model_map routing to bigmodel uses type Anthropic
         let mut map = make_test_map();
         map.insert("UPSTREAM_BIGMODEL_BASE_URL".to_string(), "http://bigmodel:11434".to_string());
         map.insert("UPSTREAM_BIGMODEL_TYPE".to_string(), "anthropic".to_string());
@@ -1063,7 +1073,7 @@ mod tests {
     fn test_unknown_upstream_name_in_get_type() {
         let map = make_test_map();
         let config = Config::from_map(&map).unwrap();
-        // Completely unknown upstream → falls back to global
+        // Completely unknown upstream -> falls back to global
         assert_eq!(config.get_upstream_type("nonexistent"), UpstreamType::NIM);
     }
 }

--- a/src/config_cmd.rs
+++ b/src/config_cmd.rs
@@ -73,7 +73,7 @@ fn config_show(config_path: Option<PathBuf>) -> Result<()> {
         for (claude_id, route) in entries {
             let route_type = config.get_upstream_type(&route.upstream_name);
             eprintln!(
-                " {} → {}:{} [type={}]",
+                " {} -> {}:{} [type={}]",
                 style(claude_id).dim(),
                 style(&route.upstream_name).cyan(),
                 style(&route.target_model).green(),
@@ -227,7 +227,7 @@ fn config_test(config_path: Option<PathBuf>) -> Result<()> {
             );
         }
         Err(e) => {
-            eprintln!("  {} CC binary: {}", style("⚠️").yellow(), e);
+            eprintln!("  {} CC binary: {}", style("[WARN]").yellow(), e);
         }
     }
 
@@ -239,7 +239,7 @@ fn config_test(config_path: Option<PathBuf>) -> Result<()> {
             eprintln!("  {} Proxy healthy at port {}", style("✅").green(), config.port);
         }
         Ok(resp) => {
-            eprintln!("  {} Proxy responded: {}", style("⚠️").yellow(), resp.status());
+            eprintln!("  {} Proxy responded: {}", style("[WARN]").yellow(), resp.status());
         }
         Err(_) => {
             eprintln!("  {} Proxy not running on port {}", style("ℹ️").blue(), config.port);
@@ -250,7 +250,7 @@ fn config_test(config_path: Option<PathBuf>) -> Result<()> {
     if !config.model_map.is_empty() {
         eprintln!("  {} {} model mappings configured", style("✅").green(), config.model_map.len());
     } else {
-        eprintln!("  {} No model mappings — run: nexus-ai-gateway setup", style("⚠️").yellow());
+        eprintln!("  {} No model mappings — run: nexus-ai-gateway setup", style("[WARN]").yellow());
     }
 
     eprintln!();

--- a/src/error.rs
+++ b/src/error.rs
@@ -58,10 +58,10 @@ pub enum ProxyError {
 
 /// Map HTTP status to Anthropic-native error type.
 /// CC uses these types to decide retry behaviour:
-///   - "rate_limit_error" → CC retries internally
-///   - "overloaded_error" → CC retries internally
-///   - "api_error" → CC retries internally
-///   - Others → CC shows error to user
+///   - "rate_limit_error" -> CC retries internally
+///   - "overloaded_error" -> CC retries internally
+///   - "api_error" -> CC retries internally
+///   - Others -> CC shows error to user
 pub(crate) fn anthropic_error_type(status: StatusCode) -> &'static str {
     match status.as_u16() {
         400 => "invalid_request_error",
@@ -90,11 +90,11 @@ impl IntoResponse for ProxyError {
             ProxyError::Http(err) => (StatusCode::BAD_GATEWAY, format!("HTTP error: {}", err)),
             ProxyError::Internal(msg) => (StatusCode::INTERNAL_SERVER_ERROR, msg),
             ProxyError::WebFetch(msg) => (StatusCode::BAD_GATEWAY, msg),
-            // v6.1: 400 so CC treats it as non-retriable → immediate /compact feedback
+            // v6.1: 400 so CC treats it as non-retriable -> immediate /compact feedback
             ProxyError::ContextOverflow(msg) => (StatusCode::BAD_REQUEST, msg),
-            // v0.11.0: Stream timeout → 504 Gateway Timeout (retryable)
+            // v0.11.0: Stream timeout -> 504 Gateway Timeout (retryable)
             ProxyError::StreamTimeout(msg) => (StatusCode::GATEWAY_TIMEOUT, msg),
-            // v0.11.0: Buffer overflow → 502 Bad Gateway (retryable)
+            // v0.11.0: Buffer overflow -> 502 Bad Gateway (retryable)
             ProxyError::BufferOverflow(msg) => (StatusCode::BAD_GATEWAY, msg),
         };
 

--- a/src/error_test.rs
+++ b/src/error_test.rs
@@ -40,7 +40,7 @@ mod tests {
     fn test_error_408_maps_to_api_error() {
         // HTTP 408 should map to "api_error" for CC retry
         let error_type = anthropic_error_type(StatusCode::from_u16(408).unwrap());
-        // 408 is not explicitly listed → falls through to default "api_error"
+        // 408 is not explicitly listed -> falls through to default "api_error"
         assert_eq!(error_type, "api_error");
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -94,7 +94,7 @@ fn main() -> anyhow::Result<()> {
     //     match daemonize.start() {
     //         Ok(_) => {}
     //         Err(e) => {
-    //             eprintln!("✗ Failed to daemonize: {}", e);
+    //             eprintln!("[FAIL] Failed to daemonize: {}", e);
     //             std::process::exit(1);
     //         }
     //     }
@@ -102,7 +102,7 @@ fn main() -> anyhow::Result<()> {
 
     // Temporarily disabled daemon mode
     if cli.daemon {
-        eprintln!("⚠️ Daemon mode temporarily disabled (daemonize crate unmaintained - RUSTSEC-2025-0069). Use systemd service instead.");
+        eprintln!("[WARN] Daemon mode temporarily disabled (daemonize crate unmaintained - RUSTSEC-2025-0069). Use systemd service instead.");
         std::process::exit(1);
     }
 
@@ -146,7 +146,7 @@ async fn async_main(cli: Cli) -> anyhow::Result<()> {
     // Log telemetry disabled reason (config loads before logging, so we defer the message here)
     if !config.telemetry_enabled {
         if let Some(ref reason) = config.telemetry_disabled_reason {
-            tracing::warn!("⚠️ Telemetry auto-disabled: {reason}");
+            tracing::warn!("[WARN] Telemetry auto-disabled: {reason}");
         }
     }
 
@@ -161,7 +161,7 @@ async fn async_main(cli: Cli) -> anyhow::Result<()> {
     );
     if config.telemetry_enabled && telemetry_ctx.is_none() {
         tracing::warn!(
-            "⚠️ Telemetry was enabled but initialization failed — running without telemetry"
+            "[WARN] Telemetry was enabled but initialization failed — running without telemetry"
         );
     }
 
@@ -207,14 +207,14 @@ async fn async_main(cli: Cli) -> anyhow::Result<()> {
     match scan::scan_cc_binary() {
         Ok(result) => {
             tracing::info!(
-                "🔍 CC scan: {} models, {} tools, {} capabilities",
+                "[SCAN] CC scan: {} models, {} tools, {} capabilities",
                 result.models.len(),
                 result.tools.len(),
                 result.capabilities.len()
             );
         }
         Err(e) => {
-            tracing::warn!("⚠️ CC binary scan skipped: {}", e);
+            tracing::warn!("[WARN] CC binary scan skipped: {}", e);
         }
     }
     if let Some(ref model) = config.reasoning_model {
@@ -361,7 +361,7 @@ async fn async_main(cli: Cli) -> anyhow::Result<()> {
                 .compare_exchange(false, true, Ordering::SeqCst, Ordering::Relaxed)
                 .is_err()
             {
-                tracing::warn!("⚠️ Config reload already in progress (SIGHUP skipped)");
+                tracing::warn!("[WARN] Config reload already in progress (SIGHUP skipped)");
                 continue;
             }
             let reload_path = reload_config.load().config_path.clone();
@@ -454,11 +454,11 @@ async fn async_main(cli: Cli) -> anyhow::Result<()> {
 
         loop {
             tokio::select! {
-                // New Modify event arrived → reset debounce timer
+                // New Modify event arrived -> reset debounce timer
                 _ = rx.recv() => {
                     debounce_sleep.as_mut().reset(tokio::time::Instant::now() + debounce);
                 }
-                // Debounce expired → proceed with reload pipeline
+                // Debounce expired -> proceed with reload pipeline
                 _ = debounce_sleep.as_mut() => {
                     // S11: Skip if server is draining
                     if IS_DRAINING.load(std::sync::atomic::Ordering::Relaxed) {
@@ -494,7 +494,7 @@ async fn async_main(cli: Cli) -> anyhow::Result<()> {
                         .compare_exchange(false, true, Ordering::SeqCst, Ordering::Relaxed)
                         .is_err()
                     {
-                        tracing::warn!("⚠️ Config reload already in progress (watcher skipped)");
+                        tracing::warn!("[WARN] Config reload already in progress (watcher skipped)");
                         debounce_sleep.as_mut().reset(tokio::time::Instant::now() + debounce);
                         continue;
                     }
@@ -534,9 +534,9 @@ async fn async_main(cli: Cli) -> anyhow::Result<()> {
     // We use a dedicated CancellationToken for the server's graceful shutdown,
     // separate from SHUTDOWN_TOKEN (which cancels SSE streams). The flow is:
     // 1. Server is spawned — begins serving immediately
-    // 2. shutdown_signal() fires → sets IS_DRAINING, cancels SHUTDOWN_TOKEN
-    // 3. We then cancel server_shutdown_token → server stops accepting
-    // 4. Drain timeout starts → races against server task completing
+    // 2. shutdown_signal() fires -> sets IS_DRAINING, cancels SHUTDOWN_TOKEN
+    // 3. We then cancel server_shutdown_token -> server stops accepting
+    // 4. Drain timeout starts -> races against server task completing
     let server_shutdown_token = tokio_util::sync::CancellationToken::new();
     let server_ct_for_graceful = server_shutdown_token.clone();
     let server_handle = tokio::spawn(async move {
@@ -572,7 +572,7 @@ async fn async_main(cli: Cli) -> anyhow::Result<()> {
         }
         _ = tokio::time::sleep(drain_timeout) => {
             tracing::warn!(
-                "⏱️ Drain timeout ({}s) exceeded — forcing shutdown ({} active connections)",
+                "[TIMEOUT] Drain timeout ({}s) exceeded — forcing shutdown ({} active connections)",
                 drain_timeout_secs,
                 proxy::ACTIVE_CONNECTIONS.load(Ordering::Relaxed)
             );
@@ -696,7 +696,7 @@ fn handle_scan(env: bool, launcher: bool, check: bool) -> anyhow::Result<()> {
                     &scan_result.binary_sha256[scan_result.binary_sha256.len() - 8..]
                 );
             } else {
-                println!("⚠️ CC binary UPDATED!");
+                println!("[WARN] CC binary UPDATED!");
                 println!(" Old: {}", old_scan.binary_sha256);
                 println!(" New: {}", scan_result.binary_sha256);
                 let new_models: Vec<&str> = scan_result
@@ -743,7 +743,7 @@ fn handle_scan(env: bool, launcher: bool, check: bool) -> anyhow::Result<()> {
 
 fn stop_daemon(pid_file: &std::path::Path) -> anyhow::Result<()> {
     if !pid_file.exists() {
-        eprintln!("✗ PID file not found: {}", pid_file.display());
+        eprintln!("[FAIL] PID file not found: {}", pid_file.display());
         eprintln!(" Daemon is not running or PID file was removed");
         std::process::exit(1);
     }
@@ -758,7 +758,7 @@ fn stop_daemon(pid_file: &std::path::Path) -> anyhow::Result<()> {
         let output = Command::new("kill").arg(pid.to_string()).output()?;
 
         if !output.status.success() {
-            eprintln!("✗ Failed to stop daemon (PID: {})", pid);
+            eprintln!("[FAIL] Failed to stop daemon (PID: {})", pid);
             eprintln!(" Process may have already exited");
             std::fs::remove_file(pid_file)?;
             std::process::exit(1);
@@ -777,14 +777,14 @@ fn stop_daemon(pid_file: &std::path::Path) -> anyhow::Result<()> {
                 .unwrap_or(false);
             if !still_running {
                 eprintln!(
-                    "✓ Daemon stopped gracefully (PID: {}, elapsed: {:.1}s)",
+                    "[OK] Daemon stopped gracefully (PID: {}, elapsed: {:.1}s)",
                     pid,
                     start.elapsed().as_secs_f64()
                 );
                 break;
             }
             if start.elapsed() > max_wait {
-                eprintln!("⚠️ Daemon did not exit after 30s — sending SIGKILL...");
+                eprintln!("[WARN] Daemon did not exit after 30s — sending SIGKILL...");
                 let _ = Command::new("kill").args(["-9", &pid.to_string()]).output();
                 break;
             }
@@ -795,7 +795,7 @@ fn stop_daemon(pid_file: &std::path::Path) -> anyhow::Result<()> {
 
     #[cfg(not(unix))]
     {
-        eprintln!("✗ Daemon stop is only supported on Unix systems");
+        eprintln!("[FAIL] Daemon stop is only supported on Unix systems");
         std::process::exit(1);
     }
 
@@ -804,7 +804,7 @@ fn stop_daemon(pid_file: &std::path::Path) -> anyhow::Result<()> {
 
 fn check_status(pid_file: &std::path::Path) -> anyhow::Result<()> {
     if !pid_file.exists() {
-        eprintln!("✗ Daemon is not running");
+        eprintln!("[FAIL] Daemon is not running");
         eprintln!(" PID file not found: {}", pid_file.display());
         std::process::exit(1);
     }
@@ -819,10 +819,10 @@ fn check_status(pid_file: &std::path::Path) -> anyhow::Result<()> {
         let output = Command::new("ps").arg("-p").arg(pid.to_string()).output()?;
 
         if output.status.success() {
-            eprintln!("✓ Daemon is running (PID: {})", pid);
+            eprintln!("[OK] Daemon is running (PID: {})", pid);
             eprintln!(" PID file: {}", pid_file.display());
         } else {
-            eprintln!("✗ Daemon is not running");
+            eprintln!("[FAIL] Daemon is not running");
             eprintln!(" Stale PID file found: {} (PID: {})", pid_file.display(), pid);
             std::process::exit(1);
         }
@@ -830,7 +830,7 @@ fn check_status(pid_file: &std::path::Path) -> anyhow::Result<()> {
 
     #[cfg(not(unix))]
     {
-        eprintln!("✗ Daemon status check is only supported on Unix systems");
+        eprintln!("[FAIL] Daemon status check is only supported on Unix systems");
         std::process::exit(1);
     }
 

--- a/src/models/openai.rs
+++ b/src/models/openai.rs
@@ -20,7 +20,7 @@ pub struct OpenAIRequest {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub stream_options: Option<serde_json::Value>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub tools: Option<Vec<Tool>>,
+    pub tools: Option<Vec<ToolSpec>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub tool_choice: Option<Value>,
     /// NIM/vLLM chat template kwargs for model-specific features (e.g. GLM5 thinking)
@@ -75,7 +75,193 @@ pub struct FunctionCall {
     pub arguments: String,
 }
 
+/// Format variant for tool specifications
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub enum ToolFormat {
+    /// OpenAI format: { type: "function", function: { name, description, parameters } }
+    OpenAI,
+    /// Anthropic format: { name, description, input_schema, type? }
+    Anthropic,
+}
+
+/// Tool specification with dual-format support
+#[derive(Debug, Clone)]
+pub struct ToolSpec {
+    pub name: String,
+    pub description: Option<String>,
+    pub schema: serde_json::Value,
+    pub anthropic_type: Option<String>, // e.g. "text_editor_20250424" — only for Anthropic format
+    pub tool_format: ToolFormat,
+}
+
+impl serde::Serialize for ToolSpec {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        use serde::ser::SerializeMap;
+
+        match self.tool_format {
+            ToolFormat::OpenAI => {
+                let mut map = serializer.serialize_map(Some(2))?;
+                map.serialize_key("type")?;
+                map.serialize_value("function")?;
+
+                let mut function_map = serde_json::Map::new();
+                function_map
+                    .insert("name".to_string(), serde_json::Value::String(self.name.clone()));
+                if let Some(ref description) = self.description {
+                    function_map.insert(
+                        "description".to_string(),
+                        serde_json::Value::String(description.clone()),
+                    );
+                }
+                function_map.insert("parameters".to_string(), self.schema.clone());
+
+                map.serialize_key("function")?;
+                map.serialize_value(&function_map)?;
+                map.end()
+            }
+            ToolFormat::Anthropic => {
+                let mut map = serializer.serialize_map(None)?;
+                map.serialize_key("name")?;
+                map.serialize_value(&self.name)?;
+                if let Some(ref description) = self.description {
+                    map.serialize_key("description")?;
+                    map.serialize_value(description)?;
+                }
+                map.serialize_key("input_schema")?;
+                map.serialize_value(&self.schema)?;
+                if let Some(ref tool_type) = self.anthropic_type {
+                    map.serialize_key("type")?;
+                    map.serialize_value(tool_type)?;
+                }
+                map.end()
+            }
+        }
+    }
+}
+
+impl<'de> serde::Deserialize<'de> for ToolSpec {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        use serde::de::{MapAccess, Visitor};
+        use std::fmt;
+        use std::marker::PhantomData;
+
+        struct ToolSpecVisitor {
+            marker: PhantomData<fn() -> ToolSpec>,
+        }
+
+        impl<'de> Visitor<'de> for ToolSpecVisitor {
+            type Value = ToolSpec;
+
+            fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+                formatter.write_str("a tool specification")
+            }
+
+            fn visit_map<V>(self, mut map: V) -> Result<ToolSpec, V::Error>
+            where
+                V: MapAccess<'de>,
+            {
+                let mut tool_type: Option<String> = None;
+                let mut tool_function: Option<serde_json::Value> = None;
+                let mut name: Option<String> = None;
+                let mut description: Option<String> = None;
+                let mut _parameters: Option<serde_json::Value> = None;
+                let mut input_schema: Option<serde_json::Value> = None;
+
+                // Try to determine format by checking for "type": "function"
+                while let Some(key) = map.next_key::<String>()? {
+                    match key.as_str() {
+                        "type" => {
+                            tool_type = Some(map.next_value()?);
+                        }
+                        "function" => {
+                            tool_function = Some(map.next_value()?);
+                        }
+                        "name" => {
+                            name = map.next_value()?;
+                        }
+                        "description" => {
+                            description = map.next_value()?;
+                        }
+                        "parameters" => {
+                            _parameters = map.next_value()?;
+                        }
+                        "input_schema" => {
+                            input_schema = map.next_value()?;
+                        }
+                        _ => {
+                            // Skip unknown fields
+                            let _ = map.next_value::<serde_json::Value>()?;
+                        }
+                    }
+                }
+
+                // Determine format based on whether we have "type": "function"
+                let tool_format = if tool_type.as_deref() == Some("function") {
+                    ToolFormat::OpenAI
+                } else {
+                    ToolFormat::Anthropic
+                };
+
+                // Build the ToolSpec based on format
+                match tool_format {
+                    ToolFormat::OpenAI => {
+                        if let Some(func) = tool_function {
+                            if let Some(func_obj) = func.as_object() {
+                                let name = func_obj
+                                    .get("name")
+                                    .and_then(|v| v.as_str())
+                                    .map(|s| s.to_string())
+                                    .unwrap_or_default();
+                                let description = func_obj
+                                    .get("description")
+                                    .and_then(|v| v.as_str())
+                                    .map(|s| s.to_string());
+                                let parameters = func_obj
+                                    .get("parameters")
+                                    .cloned()
+                                    .unwrap_or(serde_json::Value::Object(serde_json::Map::new()));
+
+                                Ok(ToolSpec {
+                                    name,
+                                    description,
+                                    schema: parameters,
+                                    anthropic_type: None,
+                                    tool_format: ToolFormat::OpenAI,
+                                })
+                            } else {
+                                Err(serde::de::Error::custom("Invalid function object"))
+                            }
+                        } else {
+                            Err(serde::de::Error::custom(
+                                "Missing function field for OpenAI format",
+                            ))
+                        }
+                    }
+                    ToolFormat::Anthropic => Ok(ToolSpec {
+                        name: name.unwrap_or_default(),
+                        description,
+                        schema: input_schema
+                            .unwrap_or(serde_json::Value::Object(serde_json::Map::new())),
+                        anthropic_type: tool_type.filter(|t| t != "function"),
+                        tool_format: ToolFormat::Anthropic,
+                    }),
+                }
+            }
+        }
+
+        let visitor = ToolSpecVisitor { marker: PhantomData };
+        deserializer.deserialize_map(visitor)
+    }
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
+#[allow(dead_code)]
 pub struct Tool {
     #[serde(rename = "type")]
     pub tool_type: String,
@@ -83,6 +269,7 @@ pub struct Tool {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
+#[allow(dead_code)]
 pub struct Function {
     pub name: String,
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/src/proxy/classify.rs
+++ b/src/proxy/classify.rs
@@ -20,12 +20,12 @@ pub(crate) fn error_regexes() -> &'static ErrorRegexes {
     })
 }
 
-pub(crate) const MAX_RETRIES: u32 = 3; // Reduced from 4: less cascade amplification (1.58x→~1.3x)
+pub(crate) const MAX_RETRIES: u32 = 3; // Reduced from 4: less cascade amplification (1.58x->~1.3x)
 #[allow(dead_code)]
 pub(crate) const RETRY_BASE_MS: u64 = 1500; // Kept for reference, overridden per error class
 pub(crate) const MIN_CLAMP_TOKENS: u32 = 4096;
 
-/// Error classification: 3 layers (Structural → Status-Guard → Content-Aware → Status-Based)
+/// Error classification: 3 layers (Structural -> Status-Guard -> Content-Aware -> Status-Based)
 #[derive(Debug)]
 pub(crate) enum ErrorClass {
     /// Transient server error — retry with exponential backoff + jitter
@@ -47,6 +47,13 @@ pub(crate) const FIXABLE_PATTERNS: &[&str] = &[
     "exceeds the model",
     "input tokens",
     "reduce the length",
+    // Issue #63/#88: Tool schema format mismatch (C8)
+    "missing field `input_schema`",
+    "missing field `parameters`",
+    "failed to deserialize",
+    // Issue #74/#88: Rate limit wrapped in error (C5)
+    "rate_limit",
+    "too many requests",
 ];
 
 /// Content patterns that indicate a transient/retryable condition
@@ -96,7 +103,7 @@ pub(crate) fn extract_safe_max_tokens_from_error(message: &str) -> Option<u32> {
         context_limit.saturating_sub(real_input).saturating_sub(256).max(MIN_CLAMP_TOKENS);
 
     tracing::info!(
-        "📐 Extracted from NIM error: input={}, limit={}, safe_max={}",
+        "[CALIB] Extracted from NIM error: input={}, limit={}, safe_max={}",
         real_input,
         context_limit,
         safe_max
@@ -107,7 +114,7 @@ pub(crate) fn extract_safe_max_tokens_from_error(message: &str) -> Option<u32> {
 // ╔══════════════════════════════════════════════════════════════════════════╗
 // ║ Issue #34: Redesigned error classification with status-code guards     ║
 // ║                                                                        ║
-// ║ NEW ORDER: L0 (Structural) → StatusGuard (429/5xx) → L1 (Content) → L2║
+// ║ NEW ORDER: L0 (Structural) -> StatusGuard (429/5xx) -> L1 (Content) -> L2║
 // ║                                                                        ║
 // ║ KEY INVARIANT: L1 FATAL_PATTERNS can NEVER override a retryable        ║
 // ║ HTTP status code (429, 500-504, 529). The status code is the           ║
@@ -152,7 +159,7 @@ pub(crate) fn classify_error(upstream: &UpstreamError) -> ErrorClass {
     // ║ INVARIANT: L1 FATAL_PATTERNS cannot reach here.         ║
     // ║ The HTTP status code is the authoritative signal.       ║
     // ║ L1 can only REFINE within the Retryable class           ║
-    // ║ (e.g., Retryable→Fixable), never escalate to Fatal.    ║
+    // ║ (e.g., Retryable->Fixable), never escalate to Fatal.    ║
     // ║                                                         ║
     // ║ Fixes: M1, M2, M3, M4, M5, M6, M7                     ║
     // ╚══════════════════════════════════════════════════════════╝
@@ -163,7 +170,7 @@ pub(crate) fn classify_error(upstream: &UpstreamError) -> ErrorClass {
         if is_l2_rate_limit(upstream) {
             log_l2_rate_limit("<model>", upstream);
             tracing::warn!(
-                "⚠️ L2 rate limit detected: {} - using extended backoff",
+                "[WARN] L2 rate limit detected: {} - using extended backoff",
                 upstream.message.chars().take(100).collect::<String>()
             );
             return ErrorClass::Retryable {
@@ -184,7 +191,7 @@ pub(crate) fn classify_error(upstream: &UpstreamError) -> ErrorClass {
         }
 
         // No L1 refinement — fall through to pure status classification
-        return classify_by_status(status);
+        return classify_by_status(status, &upstream.message);
     }
 
     // ╔══════════════════════════════════════════════════════════╗
@@ -217,12 +224,12 @@ pub(crate) fn classify_error(upstream: &UpstreamError) -> ErrorClass {
     // ╔══════════════════════════════════════════════════════════╗
     // ║ LAYER 2: Status-Based Classification (fallback)         ║
     // ╚══════════════════════════════════════════════════════════╝
-    classify_by_status(status)
+    classify_by_status(status, &upstream.message)
 }
 
 /// Pure status-code classification — extracted for reuse from both
 /// the status guard path and the L2 fallback path.
-fn classify_by_status(status: u16) -> ErrorClass {
+fn classify_by_status(status: u16, error_message: &str) -> ErrorClass {
     match status {
         // Issue #34 Q1: Reduced from 3 to 1 retry for 429.
         // CC has its own 2 (SDK) + 10 (app) retries.
@@ -237,11 +244,23 @@ fn classify_by_status(status: u16) -> ErrorClass {
             max_retries: 3,
             reason: "500 internal server error (L2)",
         },
-        502 => ErrorClass::Retryable {
-            base_delay_ms: 3000,
-            max_retries: 3,
-            reason: "502 bad gateway (L2)",
-        },
+        502 => {
+            // FIX C5 (Issue #74): NIM can wrap 429 in 502 — extract rate limit from body
+            let lower_msg = error_message.to_lowercase();
+            if lower_msg.contains("429")
+                || lower_msg.contains("rate_limit")
+                || lower_msg.contains("too many requests")
+            {
+                tracing::warn!("429 wrapped in 502 detected -- reclassifying as rate limit");
+                ErrorClass::Retryable { base_delay_ms: 10000, max_retries: 1, reason: "429-in-502" }
+            } else {
+                ErrorClass::Retryable {
+                    base_delay_ms: 3000,
+                    max_retries: 3,
+                    reason: "502 bad gateway (L2)",
+                }
+            }
+        }
         503 => ErrorClass::Retryable {
             base_delay_ms: 5000,
             max_retries: 4,

--- a/src/proxy/classify_test.rs
+++ b/src/proxy/classify_test.rs
@@ -300,7 +300,7 @@ fn extract_safe_max_tokens_nim_format() {
     let safe = extract_safe_max_tokens_from_error(msg);
     assert!(safe.is_some(), "Should extract safe max from NIM format");
     let val = safe.unwrap();
-    // 131072 - 130000 - 256 = 816 → clamped to MIN_CLAMP_TOKENS (4096)
+    // 131072 - 130000 - 256 = 816 -> clamped to MIN_CLAMP_TOKENS (4096)
     assert_eq!(val, MIN_CLAMP_TOKENS);
 }
 

--- a/src/proxy/concurrency.rs
+++ b/src/proxy/concurrency.rs
@@ -29,7 +29,7 @@ pub(crate) async fn acquire_model_permit(
                 .entry(model.to_string())
                 .or_insert_with(|| {
                     tracing::info!(
-                        "🛡️ Created concurrency semaphore for '{}' ({} permits)",
+                        "[GUARD] Created concurrency semaphore for '{}' ({} permits)",
                         model,
                         max_concurrent,
                     );
@@ -72,7 +72,7 @@ pub(crate) async fn acquire_model_permit(
             Ok(permit)
         }
         Ok(Err(_)) => {
-            tracing::error!("🛡️ Semaphore CLOSED for '{}' — this is a bug", model);
+            tracing::error!("[GUARD] Semaphore CLOSED for '{}' — this is a bug", model);
             Err(ProxyError::Internal(format!("Semaphore closed for '{}'", model)))
         }
         Err(_) => {

--- a/src/proxy/discovery.rs
+++ b/src/proxy/discovery.rs
@@ -72,7 +72,7 @@ pub(crate) async fn probe_model_limit(
 ) -> Option<u32> {
     // FASE 3.6: Check if probing is disabled
     if probing_disabled() {
-        tracing::info!("[TODO] Probing disabled via DISABLE_PROBING");
+        tracing::info!("[SCAN] Probing disabled via DISABLE_PROBING");
         return None;
     }
 
@@ -115,7 +115,7 @@ pub async fn get_context_limit(
 ) -> u32 {
     // FASE 3.6: Check MODEL_LIMIT_OVERRIDES first
     if let Some(override_limit) = get_model_limit_override(model) {
-        tracing::info!("[TODO] Model limit override for {}: {}", model, override_limit);
+        tracing::info!("[SCAN] Model limit override for {}: {}", model, override_limit);
         return override_limit;
     }
 

--- a/src/proxy/discovery.rs
+++ b/src/proxy/discovery.rs
@@ -63,7 +63,7 @@ fn get_model_limit_override(model_id: &str) -> Option<u32> {
 }
 
 /// Probe NIM to discover a model's max_total_tokens.
-/// Technique: send max_tokens=999999 → NIM returns error revealing real limit.
+/// Technique: send max_tokens=999999 -> NIM returns error revealing real limit.
 pub(crate) async fn probe_model_limit(
     client: &Client,
     base_url: &str,
@@ -72,7 +72,7 @@ pub(crate) async fn probe_model_limit(
 ) -> Option<u32> {
     // FASE 3.6: Check if probing is disabled
     if probing_disabled() {
-        tracing::info!("📋 Probing disabled via DISABLE_PROBING");
+        tracing::info!("[TODO] Probing disabled via DISABLE_PROBING");
         return None;
     }
 
@@ -101,7 +101,7 @@ pub(crate) async fn probe_model_limit(
     let caps = probe_regexes().max_total_tokens.captures(&body)?;
     let limit: u32 = caps.get(1)?.as_str().parse().ok()?;
 
-    tracing::info!("🔍 Probed model '{}': max_total_tokens = {}", model, limit);
+    tracing::info!("[SCAN] Probed model '{}': max_total_tokens = {}", model, limit);
     Some(limit)
 }
 
@@ -115,7 +115,7 @@ pub async fn get_context_limit(
 ) -> u32 {
     // FASE 3.6: Check MODEL_LIMIT_OVERRIDES first
     if let Some(override_limit) = get_model_limit_override(model) {
-        tracing::info!("📋 Model limit override for {}: {}", model, override_limit);
+        tracing::info!("[TODO] Model limit override for {}: {}", model, override_limit);
         return override_limit;
     }
 
@@ -147,6 +147,10 @@ pub async fn get_context_limit(
         return limit;
     }
 
-    tracing::warn!("⚠️ Could not probe model '{}', using default {}", model, DEFAULT_CONTEXT_LIMIT);
+    tracing::warn!(
+        "[WARN] Could not probe model '{}', using default {}",
+        model,
+        DEFAULT_CONTEXT_LIMIT
+    );
     DEFAULT_CONTEXT_LIMIT
 }

--- a/src/proxy/edit_metrics.rs
+++ b/src/proxy/edit_metrics.rs
@@ -79,8 +79,13 @@ pub fn classify_edit_error(error_msg: &str) -> EditFailureType {
         EditFailureType::NotUnique
     } else if error_msg.contains("String to replace not found") {
         // Check for Unicode-related mismatch indicators
+        // Look for escaped Unicode sequences (\uXXXX) which indicate
+        // Claude Code normalized Unicode in old_string.
+        // NOTE: Do NOT check for "->" here — it's too broad and matches
+        // normal Rust syntax (fn signatures, match arms, etc.).
+        // Nuanced detection of sanitized "->" vs "->" belongs in
+        // edit_rescue.rs during fuzzy matching, not here.
         let has_unicode_markers = error_msg.contains("\\u")
-            || error_msg.contains("->")
             || error_msg.contains("[TIMEOUT]")
             || error_msg.contains("[WARN]");
         if has_unicode_markers {

--- a/src/proxy/edit_metrics.rs
+++ b/src/proxy/edit_metrics.rs
@@ -1,0 +1,151 @@
+//! Edit Audit Logger — Prometheus metrics for Edit tool outcomes
+//!
+//! Tracks Edit success/failure rates, error types, latency, and rescue
+//! effectiveness. Exposed via /metrics endpoint.
+
+use metrics::{counter, histogram};
+use std::path::Path;
+use std::time::Duration;
+
+/// Outcome of an Edit tool operation
+#[allow(dead_code)] // TODO: Wire into streaming.rs pipeline (Issue #88)
+#[derive(Debug, Clone)]
+pub enum EditOutcome {
+    Success,
+    Failed(EditFailureType),
+    Rescued,
+}
+
+/// Classification of Edit failure types
+#[allow(dead_code)] // TODO: Wire into streaming.rs pipeline (Issue #88)
+#[derive(Debug, Clone)]
+pub enum EditFailureType {
+    StringNotFound,
+    NotUnique,
+    ModifiedSinceRead,
+    InputValidation,
+    SameString,
+    UnicodeMismatch,
+}
+
+impl EditFailureType {
+    #[allow(dead_code)] // TODO: Wire into streaming.rs pipeline (Issue #88)
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Self::StringNotFound => "string_not_found",
+            Self::NotUnique => "not_unique",
+            Self::ModifiedSinceRead => "modified_since_read",
+            Self::InputValidation => "input_validation",
+            Self::SameString => "same_string",
+            Self::UnicodeMismatch => "unicode_mismatch",
+        }
+    }
+}
+
+/// Records an Edit outcome with Prometheus metrics.
+#[allow(dead_code)] // TODO: Wire into streaming.rs pipeline (Issue #88)
+pub fn record_edit_outcome(result: &EditOutcome, file_path: &str, latency: Duration) {
+    let file_basename =
+        Path::new(file_path).file_name().and_then(|n| n.to_str()).unwrap_or("unknown");
+
+    match result {
+        EditOutcome::Success => {
+            counter!("nexus_edit_total", "result" => "success".to_string()).increment(1);
+        }
+        EditOutcome::Failed(reason) => {
+            counter!("nexus_edit_total", "result" => "failure".to_string()).increment(1);
+            counter!("nexus_edit_failure_type", "type" => reason.as_str().to_string()).increment(1);
+        }
+        EditOutcome::Rescued => {
+            counter!("nexus_edit_total", "result" => "rescued".to_string()).increment(1);
+            counter!("nexus_edit_rescue_total", "result" => "rescued".to_string()).increment(1);
+        }
+    }
+
+    counter!("nexus_edit_file_path", "file" => file_basename.to_string()).increment(1);
+    histogram!("nexus_edit_latency_seconds").record(latency.as_secs_f64());
+}
+
+/// Records an Edit rescue attempt outcome.
+#[allow(dead_code)] // TODO: Wire into streaming.rs pipeline (Issue #88)
+pub fn record_edit_rescue_outcome(outcome: &str) {
+    counter!("nexus_edit_rescue_total", "result" => outcome.to_string()).increment(1);
+}
+
+/// Classifies an Edit error message into its failure type.
+#[allow(dead_code)] // TODO: Wire into streaming.rs pipeline (Issue #88)
+pub fn classify_edit_error(error_msg: &str) -> EditFailureType {
+    if error_msg.contains("not unique") {
+        EditFailureType::NotUnique
+    } else if error_msg.contains("String to replace not found") {
+        // Check for Unicode-related mismatch indicators
+        let has_unicode_markers = error_msg.contains("\\u")
+            || error_msg.contains("->")
+            || error_msg.contains("[TIMEOUT]")
+            || error_msg.contains("[WARN]");
+        if has_unicode_markers {
+            EditFailureType::UnicodeMismatch
+        } else {
+            EditFailureType::StringNotFound
+        }
+    } else if error_msg.contains("modified since read") {
+        EditFailureType::ModifiedSinceRead
+    } else if error_msg.contains("InputValidationError") {
+        EditFailureType::InputValidation
+    } else if error_msg.contains("exactly the same") {
+        EditFailureType::SameString
+    } else {
+        EditFailureType::StringNotFound // default
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_classify_string_not_found() {
+        let result = classify_edit_error("String to replace not found: foo");
+        assert!(matches!(result, EditFailureType::StringNotFound));
+    }
+
+    #[test]
+    fn test_classify_not_unique() {
+        let result = classify_edit_error("old_string is not unique in file");
+        assert!(matches!(result, EditFailureType::NotUnique));
+    }
+
+    #[test]
+    fn test_classify_modified_since_read() {
+        let result = classify_edit_error("file has been modified since read");
+        assert!(matches!(result, EditFailureType::ModifiedSinceRead));
+    }
+
+    #[test]
+    fn test_classify_input_validation() {
+        let result = classify_edit_error("InputValidationError: old_string is empty");
+        assert!(matches!(result, EditFailureType::InputValidation));
+    }
+
+    #[test]
+    fn test_classify_same_string() {
+        let result = classify_edit_error("old_string and new_string are exactly the same");
+        assert!(matches!(result, EditFailureType::SameString));
+    }
+
+    #[test]
+    fn test_classify_unicode_mismatch() {
+        let result = classify_edit_error("String to replace not found: \\u2192 result");
+        assert!(matches!(result, EditFailureType::UnicodeMismatch));
+    }
+
+    #[test]
+    fn test_failure_type_as_str() {
+        assert_eq!(EditFailureType::StringNotFound.as_str(), "string_not_found");
+        assert_eq!(EditFailureType::NotUnique.as_str(), "not_unique");
+        assert_eq!(EditFailureType::ModifiedSinceRead.as_str(), "modified_since_read");
+        assert_eq!(EditFailureType::InputValidation.as_str(), "input_validation");
+        assert_eq!(EditFailureType::SameString.as_str(), "same_string");
+        assert_eq!(EditFailureType::UnicodeMismatch.as_str(), "unicode_mismatch");
+    }
+}

--- a/src/proxy/edit_rescue.rs
+++ b/src/proxy/edit_rescue.rs
@@ -92,12 +92,42 @@ pub async fn maybe_rescue_edit(
 
     // Security: Only allow edits within the project directory
     // (prevent path traversal)
-    let canonical_path = fs::canonicalize(file_path).await.ok()?;
+    // Check the original path before canonicalization to prevent symlink attacks
+    if edit_params.file_path.contains("..") {
+        tracing::warn!(
+            "Edit rescue rejected: path contains '..' traversal: {}",
+            edit_params.file_path
+        );
+        return None;
+    }
+
+    let file_path_str = file_path.to_str().unwrap_or("");
+    if !file_path_str.starts_with("src/") && !file_path_str.starts_with("./src/") {
+        tracing::warn!(
+            "Edit rescue rejected: path outside src directory: {}",
+            edit_params.file_path
+        );
+        return None;
+    }
+
+    let canonical_path = match fs::canonicalize(file_path).await {
+        Ok(path) => path,
+        Err(e) => {
+            tracing::debug!(
+                "Edit rescue: failed to canonicalize path {}: {}",
+                edit_params.file_path,
+                e
+            );
+            return None;
+        }
+    };
+
     let cwd = std::env::current_dir().ok()?;
     if !canonical_path.starts_with(&cwd) {
         tracing::warn!(
-            "Edit rescue rejected: path outside project directory: {}",
-            edit_params.file_path
+            "Edit rescue rejected: canonicalized path outside project directory: {} -> {:?}",
+            edit_params.file_path,
+            canonical_path
         );
         return None;
     }

--- a/src/proxy/edit_rescue.rs
+++ b/src/proxy/edit_rescue.rs
@@ -12,23 +12,6 @@
 use std::path::Path;
 use tokio::fs;
 
-/// Unicode <-> ASCII mapping table for fuzzy matching.
-/// Must stay in sync with scripts/sanitize-unicode.sh
-#[allow(dead_code)] // TODO: Wire into streaming.rs pipeline (Issue #88)
-const UNICODE_MAP: &[(&str, &str)] = &[
-    ("\u{2192}", "->"),         // ->
-    ("[TIMEOUT]", "[TIMEOUT]"), // Skip: multi-char replacements are bidirectional below
-    ("[WARN]", "[WARN]"),
-    ("[OK]", "[OK]"),
-    ("[FAIL]", "[FAIL]"),
-    ("[SCAN]", "[SCAN]"),
-    ("[CALIB]", "[CALIB]"),
-    ("[GUARD]", "[GUARD]"),
-    ("[TODO]", "[TODO]"),
-    ("[LAUNCH]", "[LAUNCH]"),
-    ("[PIN]", "[PIN]"),
-];
-
 // Note: Since the Unicode sanitizer already ran (P1), source files should
 // only have ASCII. This module helps when:
 // 1. CC normalizes \uXXXX escapes in old_string (CC bug #52813)
@@ -101,6 +84,8 @@ pub async fn maybe_rescue_edit(
         return None;
     }
 
+    // Security: Restrict rescue to src/ directory only (conservative initial rollout).
+    // TODO: Consider expanding to tests/, examples/, etc. after validation (Issue #88).
     let file_path_str = file_path.to_str().unwrap_or("");
     if !file_path_str.starts_with("src/") && !file_path_str.starts_with("./src/") {
         tracing::warn!(

--- a/src/proxy/edit_rescue.rs
+++ b/src/proxy/edit_rescue.rs
@@ -1,0 +1,245 @@
+//! Edit Rescue Middleware — fuzzy Unicode matching for Edit tool failures
+//!
+//! When Claude Code's Edit tool fails with "String to replace not found",
+//! this module attempts a fuzzy match by normalizing Unicode characters
+//! bidirectionally (Unicode -> ASCII and ASCII -> Unicode).
+//!
+//! Only rescues when:
+//! - Error is exactly "String to replace not found"
+//! - The fuzzy match is unique (or replace_all=true)
+//! - Zero risk of data loss — original error returned on any ambiguity
+
+use std::path::Path;
+use tokio::fs;
+
+/// Unicode <-> ASCII mapping table for fuzzy matching.
+/// Must stay in sync with scripts/sanitize-unicode.sh
+#[allow(dead_code)] // TODO: Wire into streaming.rs pipeline (Issue #88)
+const UNICODE_MAP: &[(&str, &str)] = &[
+    ("\u{2192}", "->"),         // ->
+    ("[TIMEOUT]", "[TIMEOUT]"), // Skip: multi-char replacements are bidirectional below
+    ("[WARN]", "[WARN]"),
+    ("[OK]", "[OK]"),
+    ("[FAIL]", "[FAIL]"),
+    ("[SCAN]", "[SCAN]"),
+    ("[CALIB]", "[CALIB]"),
+    ("[GUARD]", "[GUARD]"),
+    ("[TODO]", "[TODO]"),
+    ("[LAUNCH]", "[LAUNCH]"),
+    ("[PIN]", "[PIN]"),
+];
+
+// Note: Since the Unicode sanitizer already ran (P1), source files should
+// only have ASCII. This module helps when:
+// 1. CC normalizes \uXXXX escapes in old_string (CC bug #52813)
+// 2. CC drifts full-width to half-width (CC bug #52482)
+// 3. The file being edited still contains Unicode (external files)
+
+/// Bidirectional Unicode <-> ASCII mapping for fuzzy Edit matching.
+/// Each entry maps a Unicode character to its ASCII equivalent.
+#[allow(dead_code)] // TODO: Wire into streaming.rs pipeline (Issue #88)
+const UNICODE_ASCII_MAP: &[(&str, &str)] = &[
+    ("\u{2192}", "->"),                // RIGHTWARDS ARROW
+    ("\u{23F1}\u{FE0F}", "[TIMEOUT]"), // STOPWATCH + VS16
+    ("\u{26A0}\u{FE0F}", "[WARN]"),    // WARNING SIGN + VS16
+    ("\u{2713}", "[OK]"),              // CHECK MARK
+    ("\u{2717}", "[FAIL]"),            // BALLOT X
+    ("\u{1F50D}", "[SCAN]"),           // LEFT-POINTING MAGNIFYING GLASS
+    ("\u{1F4D0}", "[CALIB]"),          // TRIANGULAR RULER
+    ("\u{1F6E1}\u{FE0F}", "[GUARD]"),  // SHIELD + VS16
+    ("\u{1F4CB}", "[TODO]"),           // CLIPBOARD
+    ("\u{1F680}", "[LAUNCH]"),         // ROCKET
+    ("\u{1F4CD}", "[PIN]"),            // ROUND PUSHPIN
+];
+
+/// Parameters extracted from an Edit tool call
+#[allow(dead_code)] // TODO: Wire into streaming.rs pipeline (Issue #88)
+#[derive(Debug)]
+pub struct EditParams {
+    pub file_path: String,
+    pub old_string: String,
+    pub new_string: String,
+    pub replace_all: bool,
+}
+
+/// Result of an Edit rescue attempt
+#[allow(dead_code)] // TODO: Wire into streaming.rs pipeline (Issue #88)
+#[derive(Debug, PartialEq)]
+pub enum EditRescueResult {
+    /// Fuzzy match succeeded — file was written with the new content
+    Rescued { new_content: String },
+    /// Could not rescue — original error should be returned
+    NotRescuable { reason: String },
+}
+
+/// Attempts to rescue a failed Edit by applying fuzzy Unicode matching.
+/// Returns None if the error is not a "String to replace not found" error.
+/// Returns Some(Rescued) if the fuzzy match succeeded.
+/// Returns Some(NotRescuable) if no variant matched.
+///
+/// This is ASYNC — reads/writes files via tokio::fs without blocking.
+#[allow(dead_code)] // TODO: Wire into streaming.rs pipeline (Issue #88)
+pub async fn maybe_rescue_edit(
+    edit_params: &EditParams,
+    error_msg: &str,
+) -> Option<EditRescueResult> {
+    if !error_msg.contains("String to replace not found") {
+        return None; // Not a matching error
+    }
+
+    // 1. Read file from disk (async, non-blocking)
+    let file_path = Path::new(&edit_params.file_path);
+
+    // Security: Only allow edits within the project directory
+    // (prevent path traversal)
+    let canonical_path = fs::canonicalize(file_path).await.ok()?;
+    let cwd = std::env::current_dir().ok()?;
+    if !canonical_path.starts_with(&cwd) {
+        tracing::warn!(
+            "Edit rescue rejected: path outside project directory: {}",
+            edit_params.file_path
+        );
+        return None;
+    }
+
+    let file_content = fs::read_to_string(&canonical_path).await.ok()?;
+
+    // 2. Generate fuzzy variants of old_string
+    let variants = generate_fuzzy_variants(&edit_params.old_string);
+
+    // 3. Try match with each variant
+    for (variant_idx, variant) in variants.iter().enumerate() {
+        if let Some(replacement) =
+            try_replace(&file_content, variant, &edit_params.new_string, edit_params.replace_all)
+        {
+            // 4. Verify uniqueness (prevent false positives)
+            let match_count = file_content.matches(variant).count();
+            if match_count == 1 || edit_params.replace_all {
+                // 5. Write modified file (async, non-blocking)
+                if fs::write(&canonical_path, &replacement).await.is_ok() {
+                    tracing::info!(
+                        "Edit rescue: fuzzy match applied in {} (variant #{}, {} chars)",
+                        edit_params.file_path,
+                        variant_idx,
+                        variant.len()
+                    );
+                    return Some(EditRescueResult::Rescued { new_content: replacement });
+                }
+            } else {
+                tracing::warn!(
+                    "Edit rescue rejected: {} ambiguous matches for variant #{} in {}",
+                    match_count,
+                    variant_idx,
+                    edit_params.file_path
+                );
+            }
+        }
+    }
+
+    Some(EditRescueResult::NotRescuable {
+        reason: "No Unicode variant produced a unique match".to_string(),
+    })
+}
+
+/// Generates multiple normalized variants of the search string.
+#[allow(dead_code)] // TODO: Wire into streaming.rs pipeline (Issue #88)
+fn generate_fuzzy_variants(original: &str) -> Vec<String> {
+    let mut variants = vec![original.to_string()];
+
+    // Strategy 1: Replace Unicode with ASCII
+    let mut ascii_version = original.to_string();
+    for (unicode, ascii) in UNICODE_ASCII_MAP {
+        ascii_version = ascii_version.replace(unicode, ascii);
+    }
+    if ascii_version != original {
+        variants.push(ascii_version);
+    }
+
+    // Strategy 2: Replace ASCII with Unicode (bidirectional)
+    let mut unicode_version = original.to_string();
+    for (unicode, ascii) in UNICODE_ASCII_MAP {
+        unicode_version = unicode_version.replace(ascii, unicode);
+    }
+    if unicode_version != original {
+        variants.push(unicode_version);
+    }
+
+    variants
+}
+
+/// Attempts string replacement, returns new content if old string is found.
+#[allow(dead_code)] // TODO: Wire into streaming.rs pipeline (Issue #88)
+fn try_replace(content: &str, old: &str, new: &str, replace_all: bool) -> Option<String> {
+    if !content.contains(old) {
+        return None;
+    }
+    if replace_all {
+        Some(content.replace(old, new))
+    } else {
+        let idx = content.find(old)?;
+        let mut result = content.to_string();
+        result.replace_range(idx..idx + old.len(), new);
+        Some(result)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn test_edit_rescue_not_matching_error() {
+        let params = EditParams {
+            file_path: "/tmp/test.rs".to_string(),
+            old_string: "foo".to_string(),
+            new_string: "bar".to_string(),
+            replace_all: false,
+        };
+        let result = maybe_rescue_edit(&params, "other error").await;
+        assert_eq!(result, None);
+    }
+
+    #[test]
+    fn test_generate_fuzzy_variants_arrow_unicode() {
+        // Input has Unicode arrow -> Strategy 1 (Unicode->ASCII) produces a variant
+        // Strategy 2 (ASCII->Unicode) finds no "->" to replace, so only 2 variants total
+        let variants = generate_fuzzy_variants("\u{2192} result");
+        assert_eq!(variants.len(), 2); // original + ascii version
+        assert!(variants[1].contains("->"));
+    }
+
+    #[test]
+    fn test_generate_fuzzy_variants_bidirectional() {
+        // Input with ASCII "->" -> Strategy 2 produces a Unicode variant
+        let variants = generate_fuzzy_variants("foo -> bar");
+        assert!(variants.len() >= 2); // at least original + unicode version
+        assert!(variants.iter().any(|v| v.contains('\u{2192}')));
+    }
+
+    #[test]
+    fn test_generate_fuzzy_variants_ascii_only() {
+        let variants = generate_fuzzy_variants("plain ascii");
+        assert_eq!(variants.len(), 1); // only original
+    }
+
+    #[test]
+    fn test_try_replace_found() {
+        let content = "hello world";
+        let result = try_replace(content, "world", "rust", false);
+        assert_eq!(result, Some("hello rust".to_string()));
+    }
+
+    #[test]
+    fn test_try_replace_not_found() {
+        let content = "hello world";
+        let result = try_replace(content, "missing", "rust", false);
+        assert_eq!(result, None);
+    }
+
+    #[test]
+    fn test_try_replace_all() {
+        let content = "aaa bbb aaa";
+        let result = try_replace(content, "aaa", "ccc", true);
+        assert_eq!(result, Some("ccc bbb ccc".to_string()));
+    }
+}

--- a/src/proxy/error_types.rs
+++ b/src/proxy/error_types.rs
@@ -31,7 +31,7 @@ pub(crate) fn parse_upstream_error(status: u16, body: &str) -> UpstreamError {
             // NIM wraps errors: "Upstream returned 400 Bad Request: {...}"
             if let Some(inner) = extract_nested_error(&err.message) {
                 tracing::debug!(
-                    "🔍 Unwrapped nested error: {} → {}",
+                    "[SCAN] Unwrapped nested error: {} -> {}",
                     &err.message.chars().take(80).collect::<String>(),
                     &inner.message.chars().take(80).collect::<String>()
                 );
@@ -39,7 +39,11 @@ pub(crate) fn parse_upstream_error(status: u16, body: &str) -> UpstreamError {
                 // for classify_error(). Inner status is more precise than
                 // the wrapper status (e.g., NIM wraps 400 inside 502).
                 if inner.status > 0 && inner.status != err.status {
-                    tracing::debug!("🔍 Inner status override: {} → {}", err.status, inner.status);
+                    tracing::debug!(
+                        "[SCAN] Inner status override: {} -> {}",
+                        err.status,
+                        inner.status
+                    );
                     err.status = inner.status;
                 }
                 err.message = inner.message;

--- a/src/proxy/headers.rs
+++ b/src/proxy/headers.rs
@@ -44,8 +44,8 @@ impl ClientHeaders {
     /// Resolve the `anthropic-beta` header value to forward upstream.
     ///
     /// Logic (User Decision Q1, Option C):
-    /// 1. Client sends betas → merge with `PROXY_MINIMUM_BETAS`, deduplicate
-    /// 2. Client does NOT send betas (None or empty) → use only `PROXY_MINIMUM_BETAS`
+    /// 1. Client sends betas -> merge with `PROXY_MINIMUM_BETAS`, deduplicate
+    /// 2. Client does NOT send betas (None or empty) -> use only `PROXY_MINIMUM_BETAS`
     /// 3. Result: comma-separated string ready for the header
     pub(crate) fn resolve_anthropic_beta(&self) -> String {
         let mut betas: Vec<&str> = PROXY_MINIMUM_BETAS.to_vec();
@@ -67,8 +67,8 @@ impl ClientHeaders {
     /// Resolve the `anthropic-version` header value to forward upstream.
     ///
     /// Logic (User Decision Q5, Option A):
-    /// 1. Client sends `anthropic-version` → forward it
-    /// 2. If not → use default `2023-06-01`
+    /// 1. Client sends `anthropic-version` -> forward it
+    /// 2. If not -> use default `2023-06-01`
     pub(crate) fn resolve_anthropic_version(&self) -> &str {
         self.anthropic_version.as_deref().unwrap_or(DEFAULT_ANTHROPIC_VERSION)
     }

--- a/src/proxy/mod.rs
+++ b/src/proxy/mod.rs
@@ -12,6 +12,8 @@
 pub mod classify;
 pub mod concurrency;
 pub mod discovery;
+pub mod edit_metrics;
+pub mod edit_rescue;
 pub mod error_types;
 pub mod headers;
 pub mod non_streaming;
@@ -130,7 +132,7 @@ pub(crate) fn resolve_raw_cc_context_window(model_id: &str, config: &Config) -> 
     // 1. Per-model mapping (CC_MODEL_CONTEXT_WINDOWS env var)
     if let Some(&window) = config.cc_model_context_windows.get(model_id).filter(|&&w| w > 0) {
         tracing::debug!(
-            "📐 CC context window from per-model mapping: {} → {}K",
+            "[CALIB] CC context window from per-model mapping: {} -> {}K",
             model_id,
             window / 1000
         );
@@ -144,7 +146,7 @@ pub(crate) fn resolve_raw_cc_context_window(model_id: &str, config: &Config) -> 
         .filter(|&w| w > 0)
     {
         tracing::debug!(
-            "📐 CC context window from CLAUDE_CODE_AUTO_COMPACT_WINDOW: {}K",
+            "[CALIB] CC context window from CLAUDE_CODE_AUTO_COMPACT_WINDOW: {}K",
             window / 1000
         );
         return window;
@@ -154,12 +156,12 @@ pub(crate) fn resolve_raw_cc_context_window(model_id: &str, config: &Config) -> 
     if let Some(window) =
         std::env::var("CC_CONTEXT_WINDOW").ok().and_then(|v| v.parse().ok()).filter(|&w| w > 0)
     {
-        tracing::debug!("📐 CC context window from CC_CONTEXT_WINDOW: {}K", window / 1000);
+        tracing::debug!("[CALIB] CC context window from CC_CONTEXT_WINDOW: {}K", window / 1000);
         return window;
     }
 
     // 4. Default: 200K (standard for Claude Sonnet/Opus/Haiku)
-    tracing::debug!("📐 CC context window: default 200K");
+    tracing::debug!("[CALIB] CC context window: default 200K");
     200_000
 }
 
@@ -279,7 +281,7 @@ pub async fn proxy_handler(
         let safe_output =
             context_limit.saturating_sub(estimated_input).saturating_sub(256).clamp(1024, 64000);
         tracing::warn!(
-            "⚠️ Pre-check: ~{}tok + {}tok > {}tok (model={}, tiktoken). Clamping → {}",
+            "[WARN] Pre-check: ~{}tok + {}tok > {}tok (model={}, tiktoken). Clamping -> {}",
             estimated_input,
             requested_output,
             context_limit,

--- a/src/proxy/non_streaming.rs
+++ b/src/proxy/non_streaming.rs
@@ -97,7 +97,7 @@ pub(crate) async fn handle_non_streaming(
         let context_threshold = cc_context_window * context_threshold_pct / 100;
         if scaled_input_tokens > context_threshold {
             tracing::warn!(
-                "⚠️ Context nearly full ({} scaled tokens = {}% of {}K, threshold={}%) — returning ContextOverflow",
+                "[WARN] Context nearly full ({} scaled tokens = {}% of {}K, threshold={}%) — returning ContextOverflow",
                 scaled_input_tokens,
                 scaled_input_tokens * 100 / cc_context_window,
                 cc_context_window / 1000,

--- a/src/proxy/retry.rs
+++ b/src/proxy/retry.rs
@@ -100,7 +100,7 @@ pub(crate) async fn resilient_send(
         // === Smart Retry: 3-Layer Error Classification ===
         let upstream_err = parse_upstream_error(status.as_u16(), &error_text);
         tracing::debug!(
-            "🔍 Parsed error: status={}, type={:?}, param={:?}, msg={}",
+            "[SCAN] Parsed error: status={}, type={:?}, param={:?}, msg={}",
             upstream_err.status,
             upstream_err.error_type,
             upstream_err.param,
@@ -152,6 +152,22 @@ pub(crate) async fn resilient_send(
                 continue;
             }
             ErrorClass::Fixable { reason } => {
+                // Issue #63/#88: Tool schema format mismatch — strip tools and retry
+                if (reason.contains("missing field")
+                    || reason.contains("deserialize")
+                    || reason.contains("schema"))
+                    && attempt <= MAX_RETRIES
+                {
+                    tracing::warn!(
+                        "Tool schema mismatch (attempt {}/{}): {} -- retrying WITHOUT tools",
+                        attempt,
+                        MAX_RETRIES,
+                        reason
+                    );
+                    openai_req.tools = None;
+                    openai_req.tool_choice = None;
+                    continue;
+                }
                 if attempt >= MAX_RETRIES {
                     // v10.2: If we exhausted retries on input_tokens overflow, it's truly full
                     if reason.contains("input_tokens overflow") {
@@ -183,7 +199,7 @@ pub(crate) async fn resilient_send(
                         && OverflowLoopTracker::check_overflow_loop(&openai_req.model, real_input)
                     {
                         tracing::warn!(
-                            "🚀 Overflow loop detected for model {} at ~{}K tokens — forcing ContextOverflow",
+                            "[LAUNCH] Overflow loop detected for model {} at ~{}K tokens — forcing ContextOverflow",
                             openai_req.model,
                             real_input / 1000
                         );
@@ -201,7 +217,7 @@ pub(crate) async fn resilient_send(
                         let margin = 2048 + (attempt * 1024);
                         let safe_with_margin = safe.saturating_sub(margin).max(1024);
                         tracing::warn!(
-                            "🔧 input_tokens overflow (attempt {}/{}): NIM safe={}, margin={}, clamping max_tokens → {}",
+                            "🔧 input_tokens overflow (attempt {}/{}): NIM safe={}, margin={}, clamping max_tokens -> {}",
                             attempt, MAX_RETRIES, safe, margin, safe_with_margin
                         );
                         safe_with_margin
@@ -213,7 +229,7 @@ pub(crate) async fn resilient_send(
                     let current = openai_req.max_tokens.unwrap_or(64000);
                     let halved = (current / 2).max(MIN_CLAMP_TOKENS);
                     tracing::warn!(
-                        "🔧 {} [{}] (attempt {}/{}): clamping max_tokens {} → {}",
+                        "🔧 {} [{}] (attempt {}/{}): clamping max_tokens {} -> {}",
                         status.as_u16(),
                         reason,
                         attempt,
@@ -233,7 +249,7 @@ pub(crate) async fn resilient_send(
                     reason,
                     crate::str_utils::safe_truncate(&upstream_err.message, 500)
                 );
-                // v6.1/v10.2: input_tokens overflow → try to extract safe max_tokens
+                // v6.1/v10.2: input_tokens overflow -> try to extract safe max_tokens
                 if reason.contains("input_tokens overflow") {
                     return Err(ProxyError::ContextOverflow(format!(
                         "Context window full: {}. Use /compact to reduce context.",
@@ -327,7 +343,7 @@ pub(crate) async fn resilient_send_raw(
         // === Smart Retry: 3-Layer Error Classification [stream] ===
         let upstream_err = parse_upstream_error(status.as_u16(), &error_text);
         tracing::debug!(
-            "🔍 [stream] Parsed error: status={}, type={:?}, param={:?}, msg={}",
+            "[SCAN] [stream] Parsed error: status={}, type={:?}, param={:?}, msg={}",
             upstream_err.status,
             upstream_err.error_type,
             upstream_err.param,
@@ -379,6 +395,22 @@ pub(crate) async fn resilient_send_raw(
                 continue;
             }
             ErrorClass::Fixable { reason } => {
+                // Issue #63/#88: Tool schema format mismatch — strip tools and retry
+                if (reason.contains("missing field")
+                    || reason.contains("deserialize")
+                    || reason.contains("schema"))
+                    && attempt <= MAX_RETRIES
+                {
+                    tracing::warn!(
+                        "Tool schema mismatch (attempt {}/{}): {} -- retrying WITHOUT tools",
+                        attempt,
+                        MAX_RETRIES,
+                        reason
+                    );
+                    openai_req.tools = None;
+                    openai_req.tool_choice = None;
+                    continue;
+                }
                 if attempt >= MAX_RETRIES {
                     // v10.2: If we exhausted retries on input_tokens overflow, it's truly full
                     if reason.contains("input_tokens overflow") {
@@ -410,7 +442,7 @@ pub(crate) async fn resilient_send_raw(
                         && OverflowLoopTracker::check_overflow_loop(&openai_req.model, real_input)
                     {
                         tracing::warn!(
-                            "🚀 [stream] Overflow loop detected for model {} at ~{}K tokens — forcing ContextOverflow",
+                            "[LAUNCH] [stream] Overflow loop detected for model {} at ~{}K tokens — forcing ContextOverflow",
                             openai_req.model,
                             real_input / 1000
                         );
@@ -429,12 +461,12 @@ pub(crate) async fn resilient_send_raw(
                     ) {
                         // v0.11.0: Subtract safety margin to absorb NIM re-tokenization drift
                         // NIM adds ~257 tokens per retry (chat template expansion).
-                        // Without margin: attempt1=63743, NIM says input=139010 (+257) → fail
-                        // With margin: attempt1=61695, NIM says input=139010 → still fits
+                        // Without margin: attempt1=63743, NIM says input=139010 (+257) -> fail
+                        // With margin: attempt1=61695, NIM says input=139010 -> still fits
                         let margin = 2048 + (attempt * 1024); // Growing margin per retry
                         let safe_with_margin = safe.saturating_sub(margin).max(1024);
                         tracing::warn!(
-                            "🔧 [stream] input_tokens overflow (attempt {}/{}): NIM safe={}, margin={}, clamping max_tokens → {}",
+                            "🔧 [stream] input_tokens overflow (attempt {}/{}): NIM safe={}, margin={}, clamping max_tokens -> {}",
                             attempt, MAX_RETRIES, safe, margin, safe_with_margin
                         );
                         safe_with_margin
@@ -446,7 +478,7 @@ pub(crate) async fn resilient_send_raw(
                     let current = openai_req.max_tokens.unwrap_or(64000);
                     let halved = (current / 2).max(MIN_CLAMP_TOKENS);
                     tracing::warn!(
-                        "🔧 [stream] {} [{}] (attempt {}/{}): clamping max_tokens {} → {}",
+                        "🔧 [stream] {} [{}] (attempt {}/{}): clamping max_tokens {} -> {}",
                         status.as_u16(),
                         reason,
                         attempt,
@@ -466,7 +498,7 @@ pub(crate) async fn resilient_send_raw(
                     reason,
                     crate::str_utils::safe_truncate(&upstream_err.message, 500)
                 );
-                // v6.1/v10.2: input_tokens overflow → 400 (CC won't retry)
+                // v6.1/v10.2: input_tokens overflow -> 400 (CC won't retry)
                 if reason.contains("input_tokens overflow") {
                     return Err(ProxyError::ContextOverflow(format!(
                         "Context window full: {}. Use /compact to reduce context.",

--- a/src/proxy/retry.rs
+++ b/src/proxy/retry.rs
@@ -153,9 +153,10 @@ pub(crate) async fn resilient_send(
             }
             ErrorClass::Fixable { reason } => {
                 // Issue #63/#88: Tool schema format mismatch — strip tools and retry
-                if (reason.contains("missing field")
-                    || reason.contains("deserialize")
-                    || reason.contains("schema"))
+                let error_msg = upstream_err.message.to_lowercase();
+                if (error_msg.contains("missing field")
+                    || error_msg.contains("deserialize")
+                    || error_msg.contains("schema"))
                     && attempt <= MAX_RETRIES
                 {
                     tracing::warn!(
@@ -396,9 +397,10 @@ pub(crate) async fn resilient_send_raw(
             }
             ErrorClass::Fixable { reason } => {
                 // Issue #63/#88: Tool schema format mismatch — strip tools and retry
-                if (reason.contains("missing field")
-                    || reason.contains("deserialize")
-                    || reason.contains("schema"))
+                let error_msg = upstream_err.message.to_lowercase();
+                if (error_msg.contains("missing field")
+                    || error_msg.contains("deserialize")
+                    || error_msg.contains("schema"))
                     && attempt <= MAX_RETRIES
                 {
                     tracing::warn!(

--- a/src/proxy/streaming.rs
+++ b/src/proxy/streaming.rs
@@ -401,6 +401,9 @@ pub(crate) fn create_sse_stream(
                                         let reasoning_val = choice.delta.reasoning_content.as_ref()
                                             .or(choice.delta.reasoning.as_ref());
                                         if let Some(reasoning) = reasoning_val {
+                                            if reasoning.contains("<previous_reasoning") {
+                                                reasoning_poisoned = true;
+                                            }
                                             if !reasoning_poisoned {
                                                 let emit_text = if reasoning.contains("<previous_reasoning") {
                                                     let pos = reasoning.find("<previous_reasoning").unwrap_or(0);
@@ -577,16 +580,14 @@ pub(crate) fn create_sse_stream(
                                                         // FIX C10 (Issue #80): If arguments is None but tool_use is open and we
                                                         // already have previous arguments, emit empty input_json_delta to keep
                                                         // the block valid. Without this, the tool_use block stays open with no deltas.
-                                                        if !tool_call_args.is_empty() {
-                                                            let event = json!({
-                                                                "type": "content_block_delta",
-                                                                "index": content_index,
-                                                                "delta": { "type": "input_json_delta", "partial_json": "" }
-                                                            });
-                                                            let sse_data = format!("event: content_block_delta\ndata: {}\n\n",
-                                                                serde_json::to_string(&event).unwrap_or_default());
-                                                            yield Ok(Bytes::from(sse_data));
-                                                        }
+                                                        let event = json!({
+                                                            "type": "content_block_delta",
+                                                            "index": content_index,
+                                                            "delta": { "type": "input_json_delta", "partial_json": "" }
+                                                        });
+                                                        let sse_data = format!("event: content_block_delta\ndata: {}\n\n",
+                                                            serde_json::to_string(&event).unwrap_or_default());
+                                                        yield Ok(Bytes::from(sse_data));
                                                     }
                                                 }
                                             }

--- a/src/proxy/streaming.rs
+++ b/src/proxy/streaming.rs
@@ -116,7 +116,7 @@ pub(crate) fn create_sse_stream(
 ) -> impl Stream<Item = Result<Bytes, std::io::Error>> + Send {
     async_stream::stream! {
         tracing::debug!(
-            "📐 Auto-compact scaling: cc_context_window={}K, model_context={}K",
+            "[CALIB] Auto-compact scaling: cc_context_window={}K, model_context={}K",
             cc_context_window / 1000,
             context_limit / 1000
         );
@@ -144,7 +144,7 @@ pub(crate) fn create_sse_stream(
         let mut accumulated_input_tokens: u32 = estimated_input_tokens;
         let mut accumulated_output_tokens: u32 = 0;
         let mut saved_stop_reason: Option<String> = None;
-        let reasoning_poisoned = false;
+        let mut reasoning_poisoned = false;
 
         tokio::pin!(stream);
 
@@ -323,7 +323,7 @@ pub(crate) fn create_sse_stream(
                                         let context_threshold = cc_context_window * context_threshold_pct / 100;
                                         if scaled_for_check > context_threshold {
                                             tracing::warn!(
-                                                "⚠️ Context nearly full ({} scaled tokens = {}% of {}K, threshold={}%) — emitting error to trigger /compact",
+                                                "[WARN] Context nearly full ({} scaled tokens = {}% of {}K, threshold={}%) — emitting error to trigger /compact",
                                                 scaled_for_check,
                                                 scaled_for_check * 100 / cc_context_window,
                                                 cc_context_window / 1000,
@@ -439,6 +439,9 @@ pub(crate) fn create_sse_stream(
                                                         serde_json::to_string(&event).unwrap_or_default());
                                                     yield Ok(Bytes::from(sse_data));
                                                 }
+                                            } else {
+                                                // FIX C7 (Issue #60): Reasoning is poisoned — suppress further reasoning output
+                                                tracing::trace!("reasoning_poisoned=true: suppressing reasoning output");
                                             }
                                         }
 
@@ -451,6 +454,24 @@ pub(crate) fn create_sse_stream(
                                                 } else {
                                                     Some(content.to_string())
                                                 };
+
+                                                // Check if we're dealing with <previous_reasoning> content
+                                                if content.contains("<previous_reasoning") {
+                                                    reasoning_poisoned = true;
+                                                    tracing::debug!("reasoning_poisoned = true -- <previous_reasoning> detected in stream");
+                                                }
+
+                                                // FIX C4 (Issue #80): If current block is tool_use and sanitized_content is None,
+                                                // the content was discarded by sanitization (<previous_reasoning>), but the model
+                                                // already transitioned to generating text — close the tool_use block first.
+                                                if current_block_type.as_deref() == Some("tool_use") && sanitized_content.is_none() {
+                                                    let event = json!({"type": "content_block_stop", "index": content_index});
+                                                    let sse_data = format!("event: content_block_stop\ndata: {}\n\n",
+                                                        serde_json::to_string(&event).unwrap_or_default());
+                                                    yield Ok(Bytes::from(sse_data));
+                                                    content_index += 1;
+                                                    current_block_type = None;
+                                                }
 
                                                 if let Some(clean_content) = sanitized_content {
                                                     if current_block_type.as_deref() != Some("text") {
@@ -552,6 +573,20 @@ pub(crate) fn create_sse_stream(
                                                                 serde_json::to_string(&event).unwrap_or_default());
                                                             yield Ok(Bytes::from(sse_data));
                                                         }
+                                                    } else if !is_intercepting_fetch && current_block_type.as_deref() == Some("tool_use") {
+                                                        // FIX C10 (Issue #80): If arguments is None but tool_use is open and we
+                                                        // already have previous arguments, emit empty input_json_delta to keep
+                                                        // the block valid. Without this, the tool_use block stays open with no deltas.
+                                                        if !tool_call_args.is_empty() {
+                                                            let event = json!({
+                                                                "type": "content_block_delta",
+                                                                "index": content_index,
+                                                                "delta": { "type": "input_json_delta", "partial_json": "" }
+                                                            });
+                                                            let sse_data = format!("event: content_block_delta\ndata: {}\n\n",
+                                                                serde_json::to_string(&event).unwrap_or_default());
+                                                            yield Ok(Bytes::from(sse_data));
+                                                        }
                                                     }
                                                 }
                                             }
@@ -597,6 +632,15 @@ pub(crate) fn create_sse_stream(
                                                 tracing::info!("[WebFetch/Stream] Fetched {} chars", fetch_result.len());
 
                                                 if suppressed_block_start {
+                                                    // FIX C11 (Issue #80): Close any prior tool_use block that might be
+                                                    // open (from another tool_call in the same chunk) before emitting text.
+                                                    if current_block_type.is_some() {
+                                                        let event = json!({"type": "content_block_stop", "index": content_index});
+                                                        let sse_data = format!("event: content_block_stop\ndata: {}\n\n",
+                                                            serde_json::to_string(&event).unwrap_or_default());
+                                                        yield Ok(Bytes::from(sse_data));
+                                                        content_index += 1;
+                                                    }
                                                     let event = json!({
                                                         "type": "content_block_start",
                                                         "index": content_index,

--- a/src/scan.rs
+++ b/src/scan.rs
@@ -382,7 +382,7 @@ pub fn scan_cc_binary() -> Result<CCScanResult, String> {
     let binary_path = find_cc_binary()
         .ok_or_else(|| "Claude Code binary not found. Is `claude` in PATH?".to_string())?;
 
-    tracing::info!("🔍 Scanning CC binary: {}", binary_path.display());
+    tracing::info!("[SCAN] Scanning CC binary: {}", binary_path.display());
 
     let sha256 = compute_sha256(&binary_path)?;
     tracing::info!("📊 SHA256: {}...{}", &sha256[..8], &sha256[sha256.len() - 8..]);
@@ -452,19 +452,19 @@ pub fn display_scan(result: &CCScanResult) {
     println!("╠══════════════════════════════════════════════════╣");
     println!("║ 🔧 Tools: {} found", result.tools.len());
     for tool in &result.tools {
-        println!("║   ✓ {}", tool);
+        println!("║   [OK] {}", tool);
     }
 
     println!("╠══════════════════════════════════════════════════╣");
     println!("║ ⚡ Capabilities: {} found", result.capabilities.len());
     for cap in &result.capabilities {
-        println!("║   ✓ {}", cap);
+        println!("║   [OK] {}", cap);
     }
 
     println!("╠══════════════════════════════════════════════════╣");
     println!("║ 🌐 Env Vars: {} confirmed in binary", result.env_vars.len());
     for var in &result.env_vars {
-        println!("║   ✓ {}", var);
+        println!("║   [OK] {}", var);
     }
 
     println!("╚══════════════════════════════════════════════════╝");

--- a/src/setup.rs
+++ b/src/setup.rs
@@ -435,7 +435,7 @@ fn phase5_generate_env(
     if env_path.exists() {
         let backup_path = env_path.with_extension("env.bak");
         fs::copy(&env_path, &backup_path)?;
-        eprintln!("  {} Backed up existing .env to .env.bak", style("📋").dim());
+        eprintln!("  {} Backed up existing .env to .env.bak", style("[TODO]").dim());
     }
 
     let mut env_content = String::new();
@@ -468,7 +468,7 @@ fn phase5_generate_env(
     env_content.push('\n');
 
     // Model mappings section
-    env_content.push_str("# ─── Model Mappings (ClaudeID → upstream:NIMmodel) ─\n");
+    env_content.push_str("# ─── Model Mappings (ClaudeID -> upstream:NIMmodel) ─\n");
     for mapping in mappings {
         let env_key = mapping.claude_id.replace('-', "_");
         env_content.push_str(&format!(
@@ -532,7 +532,7 @@ fn phase6_install_verify(port: u16, _env_path: &std::path::Path) -> Result<()> {
             _ => {
                 eprintln!(
                     "  {} Failed to restart service — you may need to restart manually",
-                    style("⚠️").yellow()
+                    style("[WARN]").yellow()
                 );
             }
         }
@@ -556,7 +556,7 @@ fn phase6_install_verify(port: u16, _env_path: &std::path::Path) -> Result<()> {
         Ok(resp) => {
             eprintln!(
                 "  {} Proxy responded with {} — may need restart",
-                style("⚠️").yellow(),
+                style("[WARN]").yellow(),
                 resp.status()
             );
         }

--- a/src/telemetry/beacon.rs
+++ b/src/telemetry/beacon.rs
@@ -92,7 +92,7 @@ pub async fn send_beacon(config: &BeaconConfig, stats: &DailyStatsEntry) -> Resu
     if status.is_success() {
         tracing::info!("📡 Telemetry beacon sent (status: {status})");
     } else {
-        tracing::warn!("⚠️ Telemetry beacon failed (status: {status})");
+        tracing::warn!("[WARN] Telemetry beacon failed (status: {status})");
     }
 
     Ok(())

--- a/src/telemetry/fingerprint.rs
+++ b/src/telemetry/fingerprint.rs
@@ -181,7 +181,7 @@ pub fn classify_client_type(headers: &HeaderMap) -> ClientType {
 }
 
 /// Extract IP prefix for fingerprinting.
-/// - IPv4: first 3 octets (e.g., "192.168.1.5" → "192.168.1")
+/// - IPv4: first 3 octets (e.g., "192.168.1.5" -> "192.168.1")
 /// - IPv6: first segment (simplified — first 4 hex groups)
 /// - Loopback: "loopback"
 /// - Unspecified: "unknown"
@@ -461,7 +461,7 @@ mod tests {
         let addr2: std::net::SocketAddr = "10.0.1.99:8315".parse().unwrap();
         let fp1 = fingerprint_ip(&addr1, secret);
         let fp2 = fingerprint_ip(&addr2, secret);
-        // Same /24 prefix → same fingerprint
+        // Same /24 prefix -> same fingerprint
         assert_eq!(fp1, fp2, "IPs in same /24 prefix must produce same fingerprint");
     }
 
@@ -498,7 +498,7 @@ mod tests {
         let headers2 = header_map_with(&[("x-api-key", "sk-ant-a3-second-key-here")]);
         let fp1 = fingerprint_api_key(&headers1, secret);
         let fp2 = fingerprint_api_key(&headers2, secret);
-        // Both keys start with "sk-ant-a" (8 chars) → same fingerprint
+        // Both keys start with "sk-ant-a" (8 chars) -> same fingerprint
         assert_eq!(fp1, fp2, "API keys with same 8-char prefix must produce same fingerprint");
     }
 

--- a/src/telemetry/mod.rs
+++ b/src/telemetry/mod.rs
@@ -290,7 +290,7 @@ mod tests {
 
         assert_eq!(fp.fingerprint_ip.len(), 64, "IP fingerprint must be 64 hex chars");
         assert_eq!(fp.fingerprint_key.len(), 64, "Key fingerprint must be 64 hex chars");
-        assert_eq!(fp.client_type, ClientType::Unknown, "No User-Agent → Unknown");
+        assert_eq!(fp.client_type, ClientType::Unknown, "No User-Agent -> Unknown");
         assert_eq!(fp.message_count, 1);
         assert!(!fp.has_tool_use);
         assert!(!fp.has_system_prompt);

--- a/src/tokenizer.rs
+++ b/src/tokenizer.rs
@@ -123,7 +123,7 @@ pub fn estimate_from_openai_request(req: &OpenAIRequest) -> u32 {
     match serde_json::to_value(req) {
         Ok(val) => estimate_input_tokens(&val),
         Err(_) => {
-            tracing::warn!("⚠️ Failed to serialize OpenAIRequest for token estimation");
+            tracing::warn!("[WARN] Failed to serialize OpenAIRequest for token estimation");
             1
         }
     }
@@ -144,7 +144,7 @@ pub fn estimate_from_openai_request(req: &OpenAIRequest) -> u32 {
 use std::collections::HashMap;
 use std::sync::{Arc, RwLock};
 
-/// Per-model correction factor for tiktoken → NIM calibration.
+/// Per-model correction factor for tiktoken -> NIM calibration.
 ///
 /// Starts at 1.0 (no correction) and self-adjusts with each request.
 /// Thread-safe via `Arc<RwLock<>>` for concurrent access from async handlers.
@@ -221,7 +221,7 @@ impl CalibrationFactors {
         entry.observations += 1;
 
         tracing::debug!(
-            "📐 Calibration [{}]: {:.4} → {:.4} (observed: {:.4}, tiktoken={}, nim={}, n={})",
+            "[CALIB] Calibration [{}]: {:.4} -> {:.4} (observed: {:.4}, tiktoken={}, nim={}, n={})",
             model,
             old_factor,
             entry.factor,

--- a/src/tokenizer_test.rs
+++ b/src/tokenizer_test.rs
@@ -213,7 +213,7 @@ fn calibration_starts_at_1() {
 #[test]
 fn calibration_adjusts_with_feedback() {
     let cal = CalibrationFactors::new();
-    // tiktoken says 1000, NIM says 1100 → observed ratio = 1.1
+    // tiktoken says 1000, NIM says 1100 -> observed ratio = 1.1
     cal.update("test-model", 1000, 1100);
 
     let factor = cal.get("test-model");

--- a/src/transform.rs
+++ b/src/transform.rs
@@ -18,7 +18,7 @@ pub struct CacheMarker {
     pub cache_control_value: serde_json::Value,
 }
 
-/// Result of Anthropic → OpenAI transformation with cache metadata
+/// Result of Anthropic -> OpenAI transformation with cache metadata
 #[derive(Debug)]
 pub struct TransformResult {
     /// The transformed OpenAI request
@@ -38,7 +38,7 @@ pub(crate) fn resolve_model_and_upstream(
     // 1. Check Model Map first (highest priority)
     if let Some(route) = config.model_map.get(req_model) {
         tracing::info!(
-            "📍 Model map hit: {} → {}:{}",
+            "[PIN] Model map hit: {} -> {}:{}",
             req_model,
             route.upstream_name,
             route.target_model
@@ -50,7 +50,7 @@ pub(crate) fn resolve_model_and_upstream(
         if has_thinking { config.reasoning_model.clone() } else { config.completion_model.clone() }
             .unwrap_or_else(|| req_model.to_string());
 
-    tracing::info!("📍 Model fallback: {} → default:{}", req_model, model);
+    tracing::info!("[PIN] Model fallback: {} -> default:{}", req_model, model);
     (model, "default".to_string())
 }
 
@@ -79,7 +79,7 @@ pub fn anthropic_to_openai(
 
     // Add system message if present
     // NOTE: Some NIM models (e.g. Qwen3.5) only accept ONE system message.
-    // CC sends system as array of blocks → we consolidate into a single message.
+    // CC sends system as array of blocks -> we consolidate into a single message.
     // PHASE 15: Extract cache markers from system prompts before processing
     if let Some(anthropic::SystemPrompt::Multiple(ref messages)) = req.system {
         for m in messages {
@@ -136,7 +136,7 @@ pub fn anthropic_to_openai(
                             cache_control_value: cc.clone(),
                         });
                     }
-                    // Nested Text blocks inside ToolResult → ToolResultContent::Blocks
+                    // Nested Text blocks inside ToolResult -> ToolResultContent::Blocks
                     anthropic::ContentBlock::ToolResult {
                         content: anthropic::ToolResultContent::Blocks(tool_blocks),
                         ..
@@ -177,6 +177,12 @@ pub fn anthropic_to_openai(
         if filtered.is_empty() {
             None
         } else {
+            // Determine the tool format based on upstream type
+            let tool_format = match config.get_upstream_type(upstream_name) {
+                crate::config::UpstreamType::Anthropic => openai::ToolFormat::Anthropic,
+                _ => openai::ToolFormat::OpenAI,
+            };
+
             Some(
                 filtered
                     .into_iter()
@@ -190,13 +196,17 @@ pub fn anthropic_to_openai(
                         } else {
                             ensure_valid_schema(clean_schema(t.input_schema))
                         };
-                        openai::Tool {
-                            tool_type: "function".to_string(),
-                            function: openai::Function {
-                                name: t.name,
-                                description: t.description,
-                                parameters,
+
+                        openai::ToolSpec {
+                            name: t.name,
+                            description: t.description,
+                            schema: parameters,
+                            anthropic_type: if tool_format == openai::ToolFormat::Anthropic {
+                                t.tool_type
+                            } else {
+                                None
                             },
+                            tool_format: tool_format.clone(),
                         }
                     })
                     .collect(),
@@ -398,7 +408,7 @@ fn ensure_valid_schema(mut schema: Value) -> Value {
             obj.insert("properties".to_string(), json!({}));
         }
     } else {
-        // schema is null, empty, or non-object → replace entirely
+        // schema is null, empty, or non-object -> replace entirely
         schema = json!({"type": "object", "properties": {}});
     }
     schema

--- a/src/transform_test.rs
+++ b/src/transform_test.rs
@@ -651,7 +651,7 @@ mod tests {
 
     #[test]
     fn test_chat_template_kwargs_per_route_nim_default_anthropic_bigmodel() {
-        // Global=NIM but bigmodel=Anthropic → request to bigmodel should NOT have chat_template_kwargs
+        // Global=NIM but bigmodel=Anthropic -> request to bigmodel should NOT have chat_template_kwargs
         let mut config = test_config_with_model_map();
         // Set bigmodel upstream to Anthropic type
         config

--- a/src/watcher.rs
+++ b/src/watcher.rs
@@ -38,14 +38,14 @@ impl CCWatcher {
         let current_sha256 = match scan::compute_sha256(&self.binary_path) {
             Ok(s) => s,
             Err(e) => {
-                tracing::warn!("⚠️ Cannot compute CC binary SHA256: {}", e);
+                tracing::warn!("[WARN] Cannot compute CC binary SHA256: {}", e);
                 return false;
             }
         };
 
         if current_sha256 != self.last_sha256 {
             tracing::info!(
-                "⚠️ CC binary updated!\n   Old: {}...{}\n   New: {}...{}",
+                "[WARN] CC binary updated!\n   Old: {}...{}\n   New: {}...{}",
                 &self.last_sha256[..8],
                 &self.last_sha256[self.last_sha256.len() - 8..],
                 &current_sha256[..8],
@@ -83,7 +83,7 @@ impl CCWatcher {
 
                     // Save state
                     if let Err(e) = self.save_state() {
-                        tracing::warn!("⚠️ Cannot save scan state: {}", e);
+                        tracing::warn!("[WARN] Cannot save scan state: {}", e);
                     }
 
                     true

--- a/src/watcher.rs
+++ b/src/watcher.rs
@@ -44,7 +44,7 @@ impl CCWatcher {
         };
 
         if current_sha256 != self.last_sha256 {
-            tracing::info!(
+            tracing::warn!(
                 "[WARN] CC binary updated!\n   Old: {}...{}\n   New: {}...{}",
                 &self.last_sha256[..8],
                 &self.last_sha256[self.last_sha256.len() - 8..],

--- a/src/watcher_test.rs
+++ b/src/watcher_test.rs
@@ -3,7 +3,7 @@
 /// These tests validate the protection logic WITHOUT requiring a running
 /// notify watcher or filesystem events. They test:
 /// - Layer 1: EventKind::Modify(ModifyKind::Data) filtering
-/// - Layer 3: mtime comparison (unchanged → skip reload)
+/// - Layer 3: mtime comparison (unchanged -> skip reload)
 /// - Layer 4: Cooldown enforcement (15s minimum between reloads)
 /// - Layer 5: AtomicBool serialization (prevents concurrent reload)
 use std::sync::atomic::{AtomicBool, Ordering};
@@ -126,17 +126,17 @@ fn layer3_mtime_changed_allows_reload() {
 #[test]
 fn layer3_none_mtime_allows_reload() {
     // If we couldn't read mtime before (None), and now we can (Some),
-    // that's a change → allow reload
+    // that's a change -> allow reload
     let last_mtime: Option<std::time::SystemTime> = None;
     let current_mtime: Option<std::time::SystemTime> = Some(std::time::SystemTime::now());
 
-    assert_ne!(current_mtime, last_mtime, "Transition from None→Some mtime must allow reload");
+    assert_ne!(current_mtime, last_mtime, "Transition from None->Some mtime must allow reload");
 }
 
 #[test]
 fn layer3_both_none_skips_reload() {
     // If both are None (can't read mtime at all), the watcher
-    // logic treats them as equal → skip
+    // logic treats them as equal -> skip
     let last_mtime: Option<std::time::SystemTime> = None;
     let current_mtime: Option<std::time::SystemTime> = None;
 
@@ -155,7 +155,7 @@ fn layer4_cooldown_not_elapsed_skips_reload() {
 
     assert!(
         last_reload.elapsed().as_secs() < cooldown_secs,
-        "5s < 15s cooldown → reload MUST be skipped"
+        "5s < 15s cooldown -> reload MUST be skipped"
     );
 }
 
@@ -167,7 +167,7 @@ fn layer4_cooldown_elapsed_allows_reload() {
 
     assert!(
         last_reload.elapsed().as_secs() >= cooldown_secs,
-        "20s >= 15s cooldown → reload MUST be allowed"
+        "20s >= 15s cooldown -> reload MUST be allowed"
     );
 }
 
@@ -181,7 +181,7 @@ fn layer4_cooldown_exact_boundary_allows_reload() {
     // At exactly 15s, < 15 is false, so reload proceeds
     assert!(
         !(last_reload.elapsed().as_secs() < cooldown_secs),
-        "At exactly 15s, the `< 15` check is false → reload allowed"
+        "At exactly 15s, the `< 15` check is false -> reload allowed"
     );
 }
 

--- a/src/web_fetch.rs
+++ b/src/web_fetch.rs
@@ -115,7 +115,7 @@ pub async fn execute_fetch(
 
     // v0.11.0 (CR-05): SSRF protection — block internal/metadata IPs
     if !is_url_safe(url) {
-        tracing::warn!("🛡️ SSRF blocked: {}", url);
+        tracing::warn!("[GUARD] SSRF blocked: {}", url);
         return Err(ProxyError::WebFetch(format!(
             "URL blocked by security policy (internal/metadata address): {}",
             url
@@ -167,7 +167,7 @@ pub async fn execute_fetch(
     // Si es HTML, strip tags
     let text = strip_html_tags(&body);
     let truncated = truncate_content(&text);
-    tracing::info!("[WebFetch] HTML→text: {} → {} chars", body.len(), truncated.len());
+    tracing::info!("[WebFetch] HTML->text: {} -> {} chars", body.len(), truncated.len());
     Ok(truncated)
 }
 

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -1,7 +1,7 @@
 use wiremock::matchers::{method, path};
 use wiremock::{Mock, MockServer, ResponseTemplate};
 
-/// Test: 429 rate limit → retry with exponential backoff
+/// Test: 429 rate limit -> retry with exponential backoff
 #[tokio::test]
 async fn test_retry_on_429() {
     let mock_server = MockServer::start().await;
@@ -52,7 +52,7 @@ async fn test_retry_on_429() {
     assert!(mock_server.uri().starts_with("http://"));
 }
 
-/// Test: 400 max_tokens overflow → auto-clamp and retry
+/// Test: 400 max_tokens overflow -> auto-clamp and retry
 #[tokio::test]
 async fn test_max_tokens_clamping() {
     let mock_server = MockServer::start().await;


### PR DESCRIPTION
## Summary

Global fix addressing 11 interconnected bugs across 4 GitHub Issues (#63, #74, #80, #60), linked by 4 causal amplification chains. Consolidated under Issue #88.

### Bug Catalog (C1-C11)

| Chain | Bug | Phase | Fix |
|-------|-----|-------|-----|
| **Chain 1: Edit Tool** | C1: Unicode mismatch causes Edit failures | P1 + P6 | Unicode sanitizer + Edit Rescue middleware |
| | C2: No audit trail for Edit outcomes | S6 | Prometheus metrics for Edit outcomes |
| **Chain 2: SSE Protocol** | C4: Missing content_block_stop on tool_call_end | P2 | Emit content_block_stop before new block |
| | C10: Missing input_json_delta when arguments=None | P2 | Emit empty input_json_delta |
| | C11: WebFetch suppression doesn't close open blocks | P2 | Close open block before suppressed_block_start |
| **Chain 3: Transform** | C6: has_thinking hardcoded true for all upstreams | P7 | Conditional on upstream_type |
| | C8: Tools always sent in OpenAI format | P3 | Dual-Format ToolSpec (OpenAI vs Anthropic) |
| | C9: reasoning_poisoned dead code (immutable let) | P5 | Mutable + detection + suppression |
| **Chain 4: Error Handling** | C3: NIM wraps 429 in 502, misclassified | P4 | Parse 502 body for rate-limit signals |
| | C5: 422 for schema mismatch is fatal, not fixable | P3 | FIXABLE_PATTERNS + retry strips tools |

### Implementation Phases

- **P1**: Unicode Sanitizer script + Taskfile + pre-commit integration (C1, C2)
- **P2**: Streaming State Machine fixes — content_block_stop, empty input_json_delta, WebFetch block close (C4, C10, C11)
- **P3**: Dual-Format ToolSpec (custom Serialize/Deserialize) + FIXABLE_PATTERNS for schema mismatch + retry handler (C6, C8, C5)
- **P4**: 429-in-502 unwrapping in classify.rs (C3, C5)
- **P5**: reasoning_poisoned mutable + detection + suppression (C3, C9)
- **P6**: Edit Rescue middleware — async fuzzy Unicode matching (C1, C2)
- **P7**: has_thinking conditional on upstream_type (C6)
- **S6**: Edit Audit Logger — Prometheus metrics (C2)

### New Files
- `scripts/sanitize-unicode.sh` — Unicode sanitizer with --dry-run/--check
- `src/proxy/edit_rescue.rs` — Fuzzy Edit rescue with bidirectional Unicode matching
- `src/proxy/edit_metrics.rs` — Prometheus metrics for Edit outcomes

### Modified Files (34 total)
- `src/proxy/streaming.rs` — SSE protocol fixes (P2, P5)
- `src/proxy/classify.rs` — 429-in-502 + FIXABLE_PATTERNS (P3, P4)
- `src/proxy/retry.rs` — Schema-fix handler in Fixable branch (P3)
- `src/transform.rs` — Dual-format tools + conditional has_thinking (P3, P7)
- `src/models/openai.rs` — ToolSpec, ToolFormat, custom Serialize/Deserialize (P3)
- `src/proxy/mod.rs` — Module declarations for edit_rescue + edit_metrics
- 25+ files — Unicode sanitization (P1)
- `Taskfile.yaml` + `scripts/hooks/pre-commit` — Sanitizer integration (P1)

## Test Plan

- [x] `cargo clippy -- -D warnings` — zero warnings
- [x] `cargo fmt --check` — passes
- [x] `cargo test` — 301+ tests passing
- [x] Pre-commit hooks pass (Unicode check + fmt + clippy)
- [ ] CI/CD pipeline passes on GitHub Actions
- [ ] CodeRabbit review — no remaining feedback
- [ ] Manual validation with NIM upstream (tools format)
- [ ] Manual validation with Anthropic upstream (tools format)

Closes #63
Closes #74
Closes #80
Closes #60
Ref: #88

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Edit Rescue middleware to auto-recover certain failed edit operations.
  * Support for tool definitions in multiple provider formats for broader compatibility.

* **Bug Fixes**
  * Improved error classification and retry behavior (better rate-limit detection).
  * More consistent streaming and tool-call handling to avoid malformed or stuck streams.

* **Chores**
  * Standardized logging/warning formatting across the app.
  * Added Unicode sanitization utilities and pre-commit checks.
  * Added edit metrics to record outcomes and rescue attempts.

* **Documentation**
  * README badge text/formatting updated.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->