### PR TITLE
ci: fix CI/CD release pipeline + CHANGELOG sync + deploy build dedup (closes #36 #41 #44)

### DIFF
--- a/.github/workflows/auto-version.yml
+++ b/.github/workflows/auto-version.yml
@@ -141,11 +141,14 @@ jobs:
           echo "$NEW" > VERSION
           sed -i "s/^version = \".*\"/version = \"$NEW\"/" Cargo.toml
           [ -f src/lib.rs ] && sed -i "s/pub const VERSION: \&str = \".*\";/pub const VERSION: \&str = \"$NEW\";/" src/lib.rs
-          if [ -f CHANGELOG.md ]; then
-            TODAY=$(date +%Y-%m-%d)
-            sed -i "s/## \[Unreleased\]/## [Unreleased]\n\n### Added\n\n### Changed\n\n### Fixed\n\n---\n\n## [$NEW] - $TODAY/" CHANGELOG.md
-          fi
-          git add VERSION Cargo.toml src/lib.rs CHANGELOG.md
+          # Refresh Cargo.lock so the workspace package version matches Cargo.toml.
+          # Without this, Cargo.lock stays at the old version and every local `cargo`
+          # command rewrites it, producing a perpetual uncommitted `M Cargo.lock`.
+          cargo update --workspace
+          # Populate CHANGELOG.md from conventional commits (Issue #44 — single source of truth)
+          chmod +x scripts/generate-changelog-entries.sh scripts/update-changelog.sh
+          ./scripts/update-changelog.sh "$NEW" "v${{ steps.analyze.outputs.current }}" || echo "::warning::CHANGELOG update skipped"
+          git add VERSION Cargo.toml src/lib.rs CHANGELOG.md Cargo.lock
           git commit -m "chore: bump version to $NEW [skip ci]"
           git tag -a "v$NEW" -m "Release v$NEW"
           git push origin main --tags
@@ -158,60 +161,14 @@ jobs:
         id: notes
         if: steps.version.outputs.new != ''
         run: |
-          NEW=${{ steps.version.outputs.new }}
           CURRENT=${{ steps.analyze.outputs.current }}
-
-          # Extract commit subjects, strip conventional commit prefix for clean descriptions
-          FEAT_RAW=$(git log "v${CURRENT}..HEAD~1" --format="%s" | grep -E "^feat" || true)
-          FIX_RAW=$(git log "v${CURRENT}..HEAD~1" --format="%s" | grep -E "^fix" || true)
-          REFACTOR_RAW=$(git log "v${CURRENT}..HEAD~1" --format="%s" | grep -E "^(refactor|perf)" || true)
-          SECURITY_RAW=$(git log "v${CURRENT}..HEAD~1" --format="%s" | grep -iE "security|audit|vulnerabilit" || true)
-          OTHER_RAW=$(git log "v${CURRENT}..HEAD~1" --format="%s" | grep -E "^(chore|ci|docs|build|style|test)" || true)
-
-          {
-            # === Added section (from feat commits) ===
-            if [ -n "$FEAT_RAW" ]; then
-              echo "### Added"
-              echo "$FEAT_RAW" | while IFS= read -r line; do
-                # Strip prefix: "feat(scope): msg" → "msg" or "feat: msg" → "msg"
-                CLEAN=$(echo "$line" | sed 's/^feat\([^)]*\)\?: //')
-                echo "- ${CLEAN^}"
-              done
-              echo ""
-            fi
-
-            # === Changed section (from refactor/perf/chore commits) ===
-            CHANGED_RAW=$(git log "v${CURRENT}..HEAD~1" --format="%s" | grep -E "^(refactor|perf|chore|ci|docs)" || true)
-            if [ -n "$CHANGED_RAW" ]; then
-              echo "### Changed"
-              echo "$CHANGED_RAW" | while IFS= read -r line; do
-                CLEAN=$(echo "$line" | sed 's/^[a-z]*\([^)]*\)\?: //')
-                echo "- ${CLEAN^}"
-              done
-              echo ""
-            fi
-
-            # === Fixed section (from fix commits) ===
-            if [ -n "$FIX_RAW" ]; then
-              echo "### Fixed"
-              echo "$FIX_RAW" | while IFS= read -r line; do
-                CLEAN=$(echo "$line" | sed 's/^fix\([^)]*\)\?: //')
-                echo "- ${CLEAN^}"
-              done
-              echo ""
-            fi
-
-            # === Security section ===
-            if [ -n "$SECURITY_RAW" ]; then
-              echo "### Security"
-              echo "$SECURITY_RAW" | while IFS= read -r line; do
-                CLEAN=$(echo "$line" | sed 's/^[a-z]*\([^)]*\)\?: //')
-                echo "- ${CLEAN^}"
-              done
-              echo ""
-            fi
-          } > /tmp/release_notes.md
-
+          # Issue #44: reuse the shared classifier so GitHub Release notes and
+          # CHANGELOG.md are generated from the exact same logic (single source of truth).
+          # HEAD~1 excludes the version-bump commit created in the previous step.
+          chmod +x scripts/generate-changelog-entries.sh
+          ./scripts/generate-changelog-entries.sh "v${CURRENT}" "HEAD~1" /tmp/release_notes.md
+          # GitHub Releases require a non-empty body
+          [ -s /tmp/release_notes.md ] || printf 'Maintenance release.\n' > /tmp/release_notes.md
           echo "body_path=/tmp/release_notes.md" >> $GITHUB_OUTPUT
 
       - name: Create GitHub Release

--- a/.github/workflows/auto-version.yml
+++ b/.github/workflows/auto-version.yml
@@ -81,6 +81,7 @@ jobs:
 
           echo "bump=$BUMP" >> $GITHUB_OUTPUT
           echo "current=$CURRENT_VERSION" >> $GITHUB_OUTPUT
+          echo "base_tag=$BASE_TAG" >> $GITHUB_OUTPUT
           echo "tag_exists=${TAG_EXISTS:-false}" >> $GITHUB_OUTPUT
           echo "total=$TOTAL" >> $GITHUB_OUTPUT
           echo "feat=$FEAT" >> $GITHUB_OUTPUT
@@ -136,6 +137,8 @@ jobs:
 
       - name: Apply version bump
         if: steps.version.outputs.new != ''
+        env:
+          BASE_TAG: ${{ steps.analyze.outputs.base_tag }}
         run: |
           NEW=${{ steps.version.outputs.new }}
           echo "$NEW" > VERSION
@@ -147,7 +150,7 @@ jobs:
           cargo update --workspace
           # Populate CHANGELOG.md from conventional commits (Issue #44 — single source of truth)
           chmod +x scripts/generate-changelog-entries.sh scripts/update-changelog.sh
-          ./scripts/update-changelog.sh "$NEW" "v${{ steps.analyze.outputs.current }}" || echo "::warning::CHANGELOG update skipped"
+          ./scripts/update-changelog.sh "$NEW" "$BASE_TAG" || echo "::warning::CHANGELOG update skipped"
           git add VERSION Cargo.toml src/lib.rs CHANGELOG.md Cargo.lock
           git commit -m "chore: bump version to $NEW [skip ci]"
           git tag -a "v$NEW" -m "Release v$NEW"
@@ -160,13 +163,14 @@ jobs:
       - name: Generate release notes
         id: notes
         if: steps.version.outputs.new != ''
+        env:
+          BASE_TAG: ${{ steps.analyze.outputs.base_tag }}
         run: |
-          CURRENT=${{ steps.analyze.outputs.current }}
           # Issue #44: reuse the shared classifier so GitHub Release notes and
           # CHANGELOG.md are generated from the exact same logic (single source of truth).
           # HEAD~1 excludes the version-bump commit created in the previous step.
           chmod +x scripts/generate-changelog-entries.sh
-          ./scripts/generate-changelog-entries.sh "v${CURRENT}" "HEAD~1" /tmp/release_notes.md
+          ./scripts/generate-changelog-entries.sh "$BASE_TAG" "HEAD~1" /tmp/release_notes.md
           # GitHub Releases require a non-empty body
           [ -s /tmp/release_notes.md ] || printf 'Maintenance release.\n' > /tmp/release_notes.md
           echo "body_path=/tmp/release_notes.md" >> $GITHUB_OUTPUT

--- a/.gitignore
+++ b/.gitignore
@@ -63,3 +63,14 @@ CLAUDE.md
 # Codex auto-generated (do not track)
 AGENTS.md
 
+# Local test/dev environment (entorno de pruebas aislado — setup NEXUS-094)
+# CARGO_TARGET_DIR aislado para pruebas (el watcher nunca dispara)
+/target-test/
+# hooks locales seguros (sin deployers de prod)
+.githooks-local/
+# cache de checksums de go-task
+.task/
+# runtime local de orquestación
+.omo/
+# Nota: .env.test ya está cubierto por ".env.*" arriba
+

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,25 +5,6 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.5.0] - 2026-04-09
-
-### Added
-- Initial release of NEXUS-AI-Gateway
-- High-performance Anthropic API proxy to OpenAI-compatible endpoints
-- Support for streaming responses
-- Rate limiting and retry mechanisms
-- Environment-based configuration
-- Daemon mode support
-- Comprehensive observability with tracing
-
-### Changed
-- Renamed project from `nexus-brain` to `nexus-ai-gateway`
-- Updated binary name in Cargo.toml
-
-### Security
-- Added security scanning to CI pipeline
-- Implemented proper error handling
-
 ## [Unreleased]
 
 ### Added
@@ -36,161 +17,188 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.19.1] - 2026-06-06
 
-### Added
-
 ### Changed
+- Add .repo identity file to .gitignore
+- Upgrade Rust toolchain to 1.96, update dependencies
 
 ### Fixed
+- Address CodeRabbit Round 2 feedback — 1 Major + 1 Minor + 3 outside-diff
+- Address CodeRabbit feedback — 3 Major + 2 Minor issues (PR #89)
+- Global fix for Issues #63, #74, #80, #60 — 11 interconnected bugs (Issue #88)
 
 ---
 
 ## [0.19.0] - 2026-06-04
 
 ### Added
-
-### Changed
-
-### Fixed
+- Telemetry always-on by default with obfstr protection
 
 ---
 
 ## [0.18.2] - 2026-06-04
 
-### Added
-
-### Changed
-
-### Fixed
+_No release notes recorded._
 
 ---
 
 ## [0.18.1] - 2026-06-03
 
-### Added
-
-### Changed
-
-### Fixed
+_No release notes recorded._
 
 ---
 
 ## [0.18.0] - 2026-06-03
 
 ### Added
-
-### Changed
+- Wire telemetry beacon — daily POST to configured endpoint
+- Expand ClientType detection — classify Cline, Aider, Continue, Codex, Cursor, Windsurf, Copilot
+- Add privacy-first telemetry module for anonymous usage statistics
+- Feat(#85): implement 3-layer autonomous git sync system
 
 ### Fixed
+- Remove no-op .git/hooks/ entries from .gitignore
+- Remove stale #[allow(dead_code)] on telemetry_beacon_url
+- Actualizar .gitignore para incluir nuevos patrones de archivos temporales
+- Telemetry Phase 0 bug fixes — gauge update, disabled reason, gitignore
+- Honor explicit telemetry paths when $HOME is unset
+- Address CodeRabbit review — 5 telemetry safety and correctness fixes
+- Fix(#85): address CodeRabbit review — 6 safety and correctness fixes
 
 ---
 
 ## [0.17.4] - 2026-05-30
 
-### Added
-
 ### Changed
+- Chore(#52): trigger CodeRabbit re-review
+- Chore(deps): bump the cargo-minor-patch group across 1 directory with 6 updates
 
 ### Fixed
+- Fix(#52): address CodeRabbit feedback — preserve config_path in reload()
+- Fix(#52): eliminate file watcher infinite reload loop with 5-layer protection
 
 ---
 
 ## [0.17.3] - 2026-05-29
 
-### Added
-
-### Changed
-
 ### Fixed
+- CodeRabbit review — 3 fixes for PR #82
+- Fix(headers): Issue #35 — Anthropic header handling (6 bugs)
+- Fix(stream): CR1-CR4 — eliminate stream timeout errors
 
 ---
 
 ## [0.17.2] - 2026-05-28
 
-### Added
-
-### Changed
-
 ### Fixed
+- Fix(classify): Issue #34 — redesign error classification with status-code guards
+- Fix(emergency): P0 timeout 300s + P2 x-should-retry headers
 
 ---
 
 ## [0.17.1] - 2026-05-04
 
-### Added
-
 ### Changed
+- Reorder TokenScalingParams + clarify output=0 calls
+- Extract token_scaling module + fix P1-P5 (Issue #33)
+- Chore(deps): bump the cargo-minor-patch group with 2 updates
+- Ignore wiremock >=0.6.5 in dependabot + add scheduled deps monitor workflow
 
 ### Fixed
+- Resolve 3 audit findings from PR #50 forensic review
+
+### Security
+- Resolve 3 audit findings from PR #50 forensic review
 
 ---
 
 ## [0.17.0] - 2026-04-30
 
 ### Added
-
-### Changed
+- Implement graceful shutdown (Issue #30) — close all 12 gaps
 
 ### Fixed
+- Address CodeRabbit round-2 review — server spawn, portable PID check, cancellable backoff
+- Address all 7 CodeRabbit review gaps for graceful shutdown (Issue #30)
 
 ---
 
 ## [0.16.1] - 2026-04-28
 
-### Added
-
-### Changed
-
 ### Fixed
+- Sync Cargo.lock + add post-merge hook + refactor pre-push deploy
 
 ---
 
 ## [0.16.0] - 2026-04-27
 
 ### Added
-
-### Changed
+- Dynamic context window sync between Claude Code and upstream models (#31)
+- Dynamic context window sync between Claude Code and upstream models
 
 ### Fixed
+- Address CodeRabbit nitpick feedback — defensive zero filter, warn on invalid config, clarify priority docs
+- Fix(test): address CodeRabbit review — RAII EnvGuard + poison-safe mutex
 
 ---
 
 ## [0.15.1] - 2026-04-27
 
-### Added
-
 ### Changed
+- Add llms.txt for AI assistant context discovery
+- Update CLAUDE.md with current architecture and conventions
+- Rewrite README.md from scratch + refactor transform.rs cache extraction
 
 ### Fixed
+- Fix(deps): pin wiremock to 0.6.4 — 0.6.5 requires unstable let_chains
 
 ---
 
 ## [0.15.0] - 2026-04-27
 
 ### Added
+- Feat(circuit-breaker): implement CB_ENABLED, CB_THRESHOLD, CB_RECOVERY_SECS env vars
 
 ### Changed
+- Chore(deps): bump dialoguer 0.12, console 0.16, metrics-exporter-prometheus 0.18
+- Ci(dependabot): improve config — groups, limits, labels, reviewers
+- Chore(deps): bump all dependencies — rand 0.10, notify 8, wiremock 0.6, indicatif 0.18, CI actions v5-v6
 
 ### Fixed
+- Fix(deploy): replace cp+chmod with install -m 0755 to avoid ETXTBSY
+- Fix(ci): address CodeRabbit review — Taskfile YAML, deploy --locked, CI version-verify
+- Fix(deploy): add binary freshness checks to prevent stale binary bug
+- Address CodeRabbit review — remove deprecated reviewers, clamp CB params
+- Fix(test): add test-only mutex to prevent overflow_tracker race condition
+- Fix(circuit-breaker): move record_failure to only Retryable branch + exhausted retries
 
 ---
 
 ## [0.14.0] - 2026-04-26
 
-### Added
-
-### Changed
-
 ### Fixed
-
----
-
-## [0.13.0] - 2026-04-23
+- **FIX 4**: Overflow loop detector — tracks consecutive overflow events per model; 3+ identical overflows (within 5% token variation) force `ContextOverflow` error, breaking infinite retry loops
+- **FIX 5**: Configurable `ContextOverflow` threshold — `CC_OVERFLOW_THRESHOLD_PCT` env var (default 80%, range 50-95). Replaces hardcoded 90% that was unreachable at 139K tokens with GLM5
+- **FIX 6**: Non-streaming `scale_tokens` — mirrors streaming.rs token scaling logic in `non_streaming.rs`, ensuring consistent overflow detection across both request paths
 
 ### Added
+- `src/proxy/overflow_tracker.rs` — OnceLock+Mutex HashMap-based overflow loop tracking (7 unit tests)
+- `get_overflow_threshold_pct()` — configurable threshold with validation (4 unit tests)
+- Overflow loop detection in both `resilient_send` (non-streaming) and `resilient_send_raw` (streaming) retry paths
 
 ### Changed
+- `ContextOverflow` threshold default: 90% → **80%** (CC_OVERFLOW_THRESHOLD_PCT)
+- `non_streaming.rs` now receives `context_limit` parameter for token scaling parity
+- Both streaming and non-streaming paths now use `scale_tokens` + configurable threshold
 
-### Fixed
+### Testing
+- 11 new unit tests for FIX 4/5/6
+- All 43 existing tests passing
+- `cargo clippy -- -D warnings` clean
+
+### Addresses
+- Auditoria_v12 C2: Overflow Loop Pattern (CRITICAL)
+- Auditoria_v12 FIX 4, 5, 6 requirements
+- Cross-validation with Auditoria_v11 root causes RC#1 and RC#2
 
 ---
 
@@ -232,11 +240,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.12.1] - 2026-04-21
 
-### Added
-
-### Changed
-
 ### Fixed
+- Fix(ci): auto-version workflow fallback when tag missing
 
 ---
 
@@ -251,6 +256,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - WebSearch null schema handling with default valid schema (F3)
 
 ### Changed
+- **Circuit Breaker ships disabled by default** (opt-in). It is introduced in this release but stays inactive unless `CB_ENABLED=1` is set, so existing deployments are unaffected. Tunable via `CB_THRESHOLD` (default 10) and `CB_RECOVERY_SECS`.
 - HTTP connection pool increased from 10 to 50 for multi-agent scenarios
 - HTTP/2 changed from prior knowledge to ALPN negotiation (HTTP/1.1 compatible)
 - Added tcp_nodelay and tcp_keepalive for connection health
@@ -276,133 +282,182 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [0.11.1] - 2026-04-18
 
 ### Added
+- Stream timeout (120s) + buffer limit (10MB) + graceful shutdown
+- SSRF protection (RFC1918/metadata blocklist)
+- Context window scaling for CC auto-compact (Kimi 131K→200K)
+- StreamTimeout/BufferOverflow error variants
+- 10 new tests (42 total)
 
 ### Changed
+- OnceLock regex cache (~90% faster HTML stripping)
+- Unified CalibrationEntry struct (single lock)
+- Auto-rebuild binary after version bump in auto-version.sh
 
 ### Fixed
+- RwLock poison recovery (5 sites)
+- AtomicBool reload guard (SIGHUP/watcher race)
+- Thinking signature field for Anthropic protocol
+- Overflow retry safety margin (NIM re-tokenization death spiral)
+- HTTP 408 extracted from Fatal → Retryable
 
 ---
 
 ## [0.11.0] - 2026-04-18
 
-### Added
-
-### Changed
-
-### Fixed
+_No release notes recorded._
 
 ---
 
 ## [0.10.4] - 2026-04-16
 
-### Added
-
 ### Changed
-
-### Fixed
+- Perf(proxy): fix 3 performance regressions from v10.0-v10.2 update
 
 ---
 
 ## [0.10.3] - 2026-04-15
 
-### Added
-
-### Changed
-
 ### Fixed
+- Fix(deps): upgrade rustls-webpki 0.103.10→0.103.12 (RUSTSEC-2026-0098/0099)
+- Fix(proxy): auto-clamp max_tokens on input_tokens overflow instead of fatal error
 
 ---
 
 ## [0.10.2] - 2026-04-15
 
-### Added
-
 ### Changed
+- Comprehensive README rewrite for v0.10.0
 
 ### Fixed
+- Fix(proxy): sanitize content blocks for </previous_reasoning> XML leakage
 
 ---
 
 ## [0.10.1] - 2026-04-15
 
-### Added
-
-### Changed
-
 ### Fixed
+- Fix(cli): pass -c config path to config/setup subcommands + make scan flags mutually exclusive
 
 ---
 
 ## [0.10.0] - 2026-04-15
 
 ### Added
+- Setup wizard, config commands, and Option B concurrency refactor
+- Feat(config): add config show/set/test subcommands
+- Feat(setup): implement interactive setup wizard (6 phases)
+- Feat(cli): add Setup and Config subcommands with stub modules
+- Feat(config): make MAX_CONCURRENT_PER_MODEL and PERMIT_TIMEOUT_SECS configurable via .env
 
 ### Changed
+- Add dialoguer, console, indicatif deps for setup wizard
+- Add CLAUDE.md to .gitignore
 
 ### Fixed
+- Fix(config): change default PORT from 3000 to 8315
 
 ---
 
 ## [0.9.0] - 2026-04-14
 
 ### Added
+- Feat(installer): auto-configure claude --effort max wrapper in bashrc
+- Feat(logging): capture CC thinking/effort params for forensic analysis
 
 ### Changed
+- Update Cargo.lock from release build
+- Ci(hooks): auto-pull after push to sync GitHub Actions version bumps
 
 ### Fixed
+- Fix(installer): cleanup claude wrapper from bashrc on uninstall
 
 ---
 
 ## [0.8.0] - 2026-04-13
 
 ### Added
-
-### Changed
-
-### Fixed
+- Feat(calibration): dynamic per-model token calibration + auto-deploy via systemd [v8.0]
 
 ---
 
 ## [0.7.0] - 2026-04-13
 
 ### Added
-
-### Changed
-
-### Fixed
+- Feat(tokenizer): inject tiktoken-estimated input_tokens in message_start [v7.0]
 
 ---
 
 ## [0.6.2] - 2026-04-13
 
-### Added
-
 ### Changed
+- Add CLAUDE.md project context and update Cargo.lock
 
 ### Fixed
+- Fix(proxy): merge reasoning sanitization and auto-deploy
+- Sanitize NIM reasoning_content to prevent XML tool call leakage
 
 ---
 
 ## [0.6.1] - 2026-04-12
 
-### Added
-
 ### Changed
+- Rewrite README with complete LOC-by-LOC architecture documentation
+- Match release notes format to v0.5.0 Keep a Changelog style
+- Upgrade to Node.js 24 actions and professional release notes
 
 ### Fixed
+- Remove legacy nexus-brain references and fix tracing filter module name
 
 ---
 
 ## [0.6.0] - 2026-04-12
 
 ### Added
+- Auto-versioning system based on conventional commits (`feat→minor`, `fix→patch`)
+- Auto Version & Release GitHub Actions workflow for automated releases
+- Portable git hooks in `scripts/hooks/` with `core.hooksPath` configuration
+- Post-commit hook showing pending version bump preview
+- Pre-push validation hook with version sync, tests, and security audit
+- Version sync integration tests (`tests/version_sync.rs`)
+- Setup automation (`task setup`, `task setup-hooks`)
+- systemd user service installer with log rotation
+- Taskfile commands: `auto-version`, `version-check`, `full-release`
 
 ### Changed
-
-### Deprecated
-
-### Removed
+- Upgraded GitHub Actions from `actions-rs/toolchain@v1` to `dtolnay/rust-toolchain@stable`
+- Upgraded `actions/cache` from v3 to v4
+- Enhanced `bump-version.sh` with CHANGELOG integration and 3-way verification
+- Consolidated cache paths in CI pipeline
 
 ### Fixed
+- Re-applied deferred `message_delta` (Fix 4) lost in previous commit
+- Resolved clippy errors and stream cutoff bug
+- Fixed CI cache key typo (`argo-index` → `cargo-index`)
 
 ### Security
+- Updated dependencies to fix security vulnerabilities
+- Added `cargo audit` to pre-push hook validation
+- Non-blocking security scan in CI pipeline
+
+---
+
+## [0.5.0] - 2026-04-09
+
+### Added
+- Initial release of NEXUS-AI-Gateway
+- High-performance Anthropic API proxy to OpenAI-compatible endpoints
+- Support for streaming responses
+- Rate limiting and retry mechanisms
+- Environment-based configuration
+- Daemon mode support
+- Comprehensive observability with tracing
+
+### Changed
+- Renamed project from `nexus-brain` to `nexus-ai-gateway`
+- Updated binary name in Cargo.toml
+
+### Security
+- Added security scanning to CI pipeline
+- Implemented proper error handling
+
+---

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1382,7 +1382,7 @@ dependencies = [
 
 [[package]]
 name = "nexus-ai-gateway"
-version = "0.19.0"
+version = "0.19.1"
 dependencies = [
  "anyhow",
  "arc-swap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -95,8 +95,8 @@ obfstr = "0.4"
 wiremock = "0.6" # Pinned: 0.6.5 uses unstable let_chains (nightly-only)
 
 [profile.release]
-opt-level = "z"        # Optimize for size
-lto = true             # Enable Link Time Optimization
-codegen-units = 1      # Better optimization
-strip = true           # Strip symbols for smaller binary
-panic = "abort"        # Smaller binary
+opt-level = "z"        # size-optimized proxy binary
+lto = "thin"           # thin LTO: bajo pico de RAM (cabe en 13GB) + ~95% del beneficio de fat LTO — soluciona el OOM
+codegen-units = 1      # menor tamano de binario
+strip = true           # quitar simbolos
+panic = "abort"        # binario mas pequeno, sin unwinding

--- a/scripts/backfill-changelog.sh
+++ b/scripts/backfill-changelog.sh
@@ -1,0 +1,105 @@
+#!/usr/bin/env bash
+# backfill-changelog.sh — One-time maintenance: reconcile CHANGELOG.md with GitHub Releases.
+#
+# Issue #44: CHANGELOG.md historically accumulated empty "### Added/Changed/Fixed"
+# placeholders while the real content lived only in GitHub Releases. This script:
+#   1. Fetches every GitHub Release body (the source of truth).
+#   2. Fills each empty CHANGELOG version section from its matching release.
+#   3. Deduplicates repeated version headers (keeps the populated one).
+#   4. Reorders sections: [Unreleased] first, then versions in descending semver.
+#   5. Marks versions with no release (or an empty release body) with a placeholder.
+#
+# Idempotent-ish: re-running only refills sections that are still empty.
+# A backup is written to CHANGELOG.md.bak before any change.
+#
+# Usage:   scripts/backfill-changelog.sh
+# Env:     REPO (default enerBydev/nexus-ai-gateway), CHANGELOG_FILE (default CHANGELOG.md)
+set -euo pipefail
+
+REPO="${REPO:-enerBydev/nexus-ai-gateway}"
+CHANGELOG="${CHANGELOG_FILE:-CHANGELOG.md}"
+[ -f "$CHANGELOG" ] || { echo "backfill: $CHANGELOG not found" >&2; exit 1; }
+
+RELEASES_JSON="$(mktemp)"
+trap 'rm -f "$RELEASES_JSON"' EXIT
+
+echo "backfill: fetching releases from ${REPO} ..."
+gh api "repos/${REPO}/releases" --paginate \
+     --jq '.[] | {tag: .tag_name, body: .body}' \
+  | python3 -c "import sys,json; d=[json.loads(l) for l in sys.stdin if l.strip()]; json.dump({x['tag']:x['body'] for x in d}, open('${RELEASES_JSON}','w'))"
+
+cp "$CHANGELOG" "${CHANGELOG}.bak"
+echo "backfill: backup written to ${CHANGELOG}.bak"
+
+CHANGELOG_FILE="$CHANGELOG" RELEASES_JSON="$RELEASES_JSON" python3 - <<'PY'
+import re, json, os
+
+CHANGELOG = os.environ["CHANGELOG_FILE"]
+releases = json.load(open(os.environ["RELEASES_JSON"], encoding="utf-8"))
+
+txt = open(CHANGELOG, encoding="utf-8").read()
+m = re.search(r'(?m)^## \[', txt)
+preamble = txt[:m.start()].rstrip()
+rest = txt[m.start():]
+
+parts = re.split(r'(?m)^(## \[[^\]]+\][^\n]*)$', rest)
+blocks = []
+i = 1
+while i < len(parts):
+    header = parts[i].strip()
+    body = parts[i + 1] if i + 1 < len(parts) else ""
+    ver = re.match(r'## \[([^\]]+)\]', header).group(1)
+    blocks.append([ver, header, body])
+    i += 2
+
+def is_empty(body):
+    return not re.search(r'(?m)^- ', body)
+
+def date_of(header):
+    md = re.search(r'(\d{4}-\d{2}-\d{2})', header)
+    return md.group(1) if md else None
+
+best = {}
+for ver, header, body in blocks:
+    if ver not in best or (is_empty(best[ver][2]) and not is_empty(body)):
+        best[ver] = [ver, header, body]
+
+filled, kept, no_source = [], [], []
+for ver, blk in best.items():
+    if ver == "Unreleased":
+        continue
+    if is_empty(blk[2]):
+        rbody = releases.get("v" + ver) or ""
+        if rbody.strip():
+            date = date_of(blk[1])
+            blk[1] = f"## [{ver}] - {date}" if date else f"## [{ver}]"
+            blk[2] = rbody.strip()
+            filled.append(ver)
+        else:
+            no_source.append(ver)
+            blk[2] = "_No release notes recorded._"
+    else:
+        kept.append(ver)
+
+def semver(v):
+    try:
+        return tuple(int(x) for x in v.split("."))
+    except Exception:
+        return (0, 0, 0)
+
+versions = sorted([v for v in best if v != "Unreleased"], key=semver, reverse=True)
+ordered = (["Unreleased"] if "Unreleased" in best else []) + versions
+
+out = [preamble]
+for ver in ordered:
+    header = best[ver][1].strip()
+    body = re.sub(r'\n*-{3,}\s*$', '', best[ver][2].strip()).strip()
+    out += ["", header, "", body, "", "---"]
+open(CHANGELOG, "w", encoding="utf-8").write("\n".join(out).rstrip() + "\n")
+
+print(f"backfill: filled {len(filled)} from releases, {len(no_source)} placeholders, {len(kept)} already populated")
+if no_source:
+    print(f"backfill: no release body for: {', '.join(no_source)}")
+PY
+
+echo "backfill: done -> ${CHANGELOG}"

--- a/scripts/bump-version.sh
+++ b/scripts/bump-version.sh
@@ -46,12 +46,13 @@ if [ -f src/lib.rs ]; then
     echo "   ✅ src/lib.rs updated"
 fi
 
-# 4. Update CHANGELOG.md — move [Unreleased] to [new_version]
+# 4. Update CHANGELOG.md — populate from conventional commits (Issue #44)
 if [ -f CHANGELOG.md ]; then
-    TODAY=$(date +%Y-%m-%d)
-    # Replace [Unreleased] header with the new version + date, and add new empty Unreleased
-    sed -i "s/## \[Unreleased\]/## [Unreleased]\n\n### Added\n\n### Changed\n\n### Fixed\n\n---\n\n## [$NEW_VERSION] - $TODAY/" CHANGELOG.md
-    echo "   ✅ CHANGELOG.md updated ([$NEW_VERSION] - $TODAY)"
+    if "$(dirname "$0")/update-changelog.sh" "$NEW_VERSION"; then
+        echo "   ✅ CHANGELOG.md updated ([$NEW_VERSION])"
+    else
+        echo "   ⚠️  CHANGELOG.md update skipped (continuing)"
+    fi
 fi
 
 # 5. Verify all 3 sources match

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -257,6 +257,7 @@ ok "Built binary: ${BUILT_BINARY}"
 # already built above — same result, no second compile.
 echo ""
 info "Installing binary to ~/.cargo/bin/${BINARY_NAME}..."
+mkdir -p "${HOME}/.cargo/bin"
 if ! install -m 0755 "${BUILT_BINARY}" "${HOME}/.cargo/bin/${BINARY_NAME}"; then
     err "Installation failed"
     exit 1

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -251,10 +251,13 @@ if [[ ! -x "${BUILT_BINARY}" ]]; then
 fi
 ok "Built binary: ${BUILT_BINARY}"
 
-# --- Install binary ---
+# --- Install binary (copy build output; no redundant cargo install rebuild) ---
+# Issue #41: `cargo install --locked --path .` recompiles the whole crate in a
+# separate target dir, doubling build time. Install by copying the binary we
+# already built above — same result, no second compile.
 echo ""
-info "Installing binary (cargo install --locked --path .)..."
-if ! cargo install --locked --path .; then
+info "Installing binary to ~/.cargo/bin/${BINARY_NAME}..."
+if ! install -m 0755 "${BUILT_BINARY}" "${HOME}/.cargo/bin/${BINARY_NAME}"; then
     err "Installation failed"
     exit 1
 fi
@@ -267,8 +270,8 @@ SOURCE_MD5=$(md5sum "${BUILT_BINARY}" | awk '{print $1}')
 
 if [[ "${CARGO_MD5}" != "${SOURCE_MD5}" ]]; then
   err "CRITICAL: Binary at ~/.cargo/bin/${BINARY_NAME} does NOT match the just-built binary!"
-  warn "This should never happen with cargo install. The systemd service may run an OLD version."
-  warn "cargo install md5: ${CARGO_MD5}"
+  warn "The install copy did not match the build output. The systemd service may run an OLD version."
+  warn "installed md5:    ${CARGO_MD5}"
   warn "build output md5: ${SOURCE_MD5}"
   err "DO NOT RESTART SERVICE until this is resolved!"
   exit 1

--- a/scripts/dev-test.sh
+++ b/scripts/dev-test.sh
@@ -23,6 +23,15 @@ cd "$ROOT"
 
 export CARGO_TARGET_DIR="${CARGO_TARGET_DIR:-target-test}"
 
+# Safety: never build into the production-watched target dir. The systemd watcher
+# monitors target/release/nexus-ai-gateway, so building there would restart prod.
+case "${CARGO_TARGET_DIR%/}" in
+  target | ./target | "${ROOT}/target")
+    echo "🚨 CARGO_TARGET_DIR='${CARGO_TARGET_DIR}' is the production-watched dir. Refusing to build there." >&2
+    exit 1
+    ;;
+esac
+
 if [ ! -f .env.test ]; then
   echo "❌ Falta .env.test (config de pruebas). Cópialo de .env.example y ajusta UPSTREAM_*."
   exit 1
@@ -46,6 +55,13 @@ if [ -z "${UPSTREAM_BASE_URL:-}" ]; then
 fi
 
 MODE="${1:-debug}"
+case "$MODE" in
+  debug | release) ;;
+  *)
+    echo "❌ Modo inválido: '$MODE' (usa: debug | release)" >&2
+    exit 1
+    ;;
+esac
 echo "🧪 NEXUS TEST  ·  target=$CARGO_TARGET_DIR  ·  port=$PORT  ·  mode=$MODE   (producción :8315 intacta)"
 
 if [ "$MODE" = "release" ]; then

--- a/scripts/dev-test.sh
+++ b/scripts/dev-test.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+# ============================================================
+# dev-test.sh — Arranca una instancia AISLADA de NEXUS para pruebas / mejora continua.
+#
+# Garantías de seguridad:
+#   - NUNCA toca producción (:8315) ni el binario instalado (~/.cargo/bin).
+#   - Usa CARGO_TARGET_DIR=target-test → fuera de target/release/, que es lo único
+#     que vigila el watcher systemd → el watcher NUNCA dispara → prod jamás se reinicia.
+#   - Guardarraíl: aborta si el puerto resuelve a 8315.
+#
+# Uso:
+#   ./scripts/dev-test.sh            # build debug (rápido) y corre en :8316
+#   ./scripts/dev-test.sh release    # build release (a target-test, sigue siendo watcher-safe)
+#
+# Nota: para iterar tests/lint usa el target normal (rápido y ya watcher-safe):
+#   cargo test     cargo clippy -- -D warnings     cargo fmt
+# El target-test aislado es para CORRER el binario servidor de pruebas.
+# ============================================================
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT"
+
+export CARGO_TARGET_DIR="${CARGO_TARGET_DIR:-target-test}"
+
+if [ ! -f .env.test ]; then
+  echo "❌ Falta .env.test (config de pruebas). Cópialo de .env.example y ajusta UPSTREAM_*."
+  exit 1
+fi
+
+# Cargar .env.test al entorno (dotenvy no sobreescribe variables ya presentes)
+set -a
+# shellcheck disable=SC1091
+. ./.env.test
+set +a
+export PORT="${PORT:-8316}"
+
+# Guardarraíl: jamás el puerto de producción
+if [ "$PORT" = "8315" ]; then
+  echo "🚨 PORT=8315 es PRODUCCIÓN. Aborto. Usa 8316 u otro en .env.test."
+  exit 1
+fi
+
+if [ -z "${UPSTREAM_BASE_URL:-}" ]; then
+  echo "⚠️  UPSTREAM_BASE_URL vacío en .env.test — rellénalo antes de probar contra un upstream real."
+fi
+
+MODE="${1:-debug}"
+echo "🧪 NEXUS TEST  ·  target=$CARGO_TARGET_DIR  ·  port=$PORT  ·  mode=$MODE   (producción :8315 intacta)"
+
+if [ "$MODE" = "release" ]; then
+  cargo build --release
+  BIN="$CARGO_TARGET_DIR/release/nexus-ai-gateway"
+else
+  cargo build
+  BIN="$CARGO_TARGET_DIR/debug/nexus-ai-gateway"
+fi
+
+echo "▶  $BIN  (Ctrl-C para detener)"
+exec "$BIN"

--- a/scripts/generate-changelog-entries.sh
+++ b/scripts/generate-changelog-entries.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+# generate-changelog-entries.sh — Generate CHANGELOG content from conventional commits.
+#
+# Issue #44: single-source-of-truth for changelog/release-note generation, shared by
+# auto-version.yml, bump-version.sh and the backfill script so the same classification
+# logic produces both CHANGELOG.md entries and GitHub Release notes.
+#
+# Usage:   generate-changelog-entries.sh <from_ref> [to_ref] [out_file]
+#   <from_ref>   git ref (tag/sha) to start from (exclusive)
+#   [to_ref]     git ref to end at (default: HEAD)
+#   [out_file]   output file (default: stdout)
+#
+# Output: Keep-a-Changelog sections — ### Added / ### Changed / ### Fixed / ### Security
+# Empty sections are omitted. Prints nothing if there are no relevant commits.
+set -euo pipefail
+
+FROM_REF="${1:?Usage: $0 <from_ref> [to_ref] [out_file]}"
+TO_REF="${2:-HEAD}"
+OUT="${3:-/dev/stdout}"
+
+RANGE="${FROM_REF}..${TO_REF}"
+
+# Automated version-bump commits are noise, not user-facing changes — exclude them.
+EXCLUDE_RE='^chore(\([^)]*\))?: bump version to'
+
+# Commit subjects in RANGE matching an (extended) regex, minus the excluded noise.
+# `|| true` keeps `set -e` happy when grep finds no matches.
+subjects() {
+  git log "$RANGE" --no-merges --format='%s' | grep -E "$1" | grep -vE "$EXCLUDE_RE" || true
+}
+
+# Strip the conventional-commit prefix: "type(scope): msg" / "type!: msg" -> "msg"
+strip_prefix() {
+  sed -E 's/^[a-z]+(\([^)]*\))?!?:[[:space:]]*//'
+}
+
+# Emit a "### <title>" section from a newline-separated list of commit subjects.
+# No-op when the list is empty.
+emit_section() {
+  local title="$1" raw="$2" line first rest
+  [ -z "$raw" ] && return 0
+  printf '### %s\n' "$title"
+  printf '%s\n' "$raw" | strip_prefix | while IFS= read -r line; do
+    [ -z "$line" ] && continue
+    first=$(printf '%s' "${line:0:1}" | tr '[:lower:]' '[:upper:]')
+    rest="${line:1}"
+    printf -- '- %s%s\n' "$first" "$rest"
+  done
+  printf '\n'
+}
+
+{
+  emit_section "Added"    "$(subjects '^feat')"
+  emit_section "Changed"  "$(subjects '^(refactor|perf|chore|ci|docs|style|build)')"
+  emit_section "Fixed"    "$(subjects '^fix')"
+  emit_section "Security" "$(git log "$RANGE" --no-merges --format='%s' | grep -iE 'security|audit|vulnerabilit' | grep -vE "$EXCLUDE_RE" || true)"
+} > "$OUT"

--- a/scripts/update-changelog.sh
+++ b/scripts/update-changelog.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+# update-changelog.sh — Insert a new released version section into CHANGELOG.md,
+# populated from conventional commits via generate-changelog-entries.sh (Issue #44).
+#
+# Shared single-source-of-truth used by both bump-version.sh (manual) and
+# auto-version.yml (CI) so CHANGELOG.md is populated identically to GitHub Releases.
+#
+# Usage: update-changelog.sh <new_version> [from_ref]
+#   <new_version>  e.g. 0.20.0  (no leading 'v')
+#   [from_ref]     baseline ref for the commit range (default: most recent tag)
+#
+# Inserts "## [<new_version>] - <today>" with generated entries immediately after
+# the "## [Unreleased]" block. Idempotent: skips if the version is already present.
+set -euo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+NEW_VERSION="${1:?Usage: $0 <new_version> [from_ref]}"
+FROM_REF="${2:-$(git tag --sort=-version:refname | head -1)}"
+CHANGELOG="${CHANGELOG_FILE:-CHANGELOG.md}"
+TODAY="$(date +%Y-%m-%d)"
+
+[ -f "$CHANGELOG" ] || { echo "update-changelog: $CHANGELOG not found — skipping"; exit 0; }
+
+# Idempotency: do nothing if this version is already documented.
+ver_re="${NEW_VERSION//./\\.}"
+if grep -qE "^## \[${ver_re}\]" "$CHANGELOG"; then
+  echo "update-changelog: [$NEW_VERSION] already present — skipping"
+  exit 0
+fi
+
+ENTRIES="$(mktemp)"
+TMP="$(mktemp)"
+trap 'rm -f "$ENTRIES" "$TMP"' EXIT
+
+if [ -n "$FROM_REF" ]; then
+  "$HERE/generate-changelog-entries.sh" "$FROM_REF" HEAD "$ENTRIES" || true
+fi
+# Fallback when there are no classifiable commits.
+if [ ! -s "$ENTRIES" ]; then
+  printf '### Changed\n- Maintenance release\n\n' > "$ENTRIES"
+fi
+
+# Insert the new version block right after the "## [Unreleased]" block's "---".
+awk -v ver="$NEW_VERSION" -v date="$TODAY" -v entries="$ENTRIES" '
+  /^## \[Unreleased\]/ { seen=1; print; next }
+  (seen && !done && /^---[[:space:]]*$/) {
+    print                              # the "---" that closes [Unreleased]
+    print ""
+    print "## [" ver "] - " date
+    print ""
+    while ((getline l < entries) > 0) print l
+    close(entries)
+    print "---"
+    done=1
+    next
+  }
+  { print }
+  END { if (!done) exit 3 }
+' "$CHANGELOG" > "$TMP" || {
+  echo "update-changelog: anchor '## [Unreleased]' + '---' not found — CHANGELOG unchanged" >&2
+  exit 1
+}
+
+mv "$TMP" "$CHANGELOG"
+echo "update-changelog: inserted [$NEW_VERSION] - $TODAY (from ${FROM_REF:-<none>})"

--- a/scripts/update-changelog.sh
+++ b/scripts/update-changelog.sh
@@ -33,7 +33,12 @@ TMP="$(mktemp)"
 trap 'rm -f "$ENTRIES" "$TMP"' EXIT
 
 if [ -n "$FROM_REF" ]; then
-  "$HERE/generate-changelog-entries.sh" "$FROM_REF" HEAD "$ENTRIES" || true
+  # Fail loudly on an invalid baseline ref instead of silently using the fallback.
+  if ! git rev-parse --verify --quiet "${FROM_REF}^{commit}" >/dev/null; then
+    echo "update-changelog: invalid from_ref '${FROM_REF}'" >&2
+    exit 1
+  fi
+  "$HERE/generate-changelog-entries.sh" "$FROM_REF" HEAD "$ENTRIES"
 fi
 # Fallback when there are no classifiable commits.
 if [ ! -s "$ENTRIES" ]; then


### PR DESCRIPTION
## Summary

Unified fix for the three **CI/CD-cluster** issues — **#41, #44, #36** — plus build/dev-env hardening. The fourth related issue, **#45** (config hot-reload), is intentionally a **separate Rust PR** (PR-B): it shares no files with these and is a different domain (runtime `config.rs`/`main.rs`), so bundling it would mix concerns and couple review risk.

Closes #41, closes #44, closes #36.

## What & why

### #41 — Deploy pipeline redundant build  · `ci`
`scripts/deploy.sh` ran `cargo build --release` **and then** `cargo install --locked --path .`, recompiling the entire crate a second time in a separate target dir. Now it installs by **copying the already-built binary** (same pattern as the pre-push/post-merge hooks) → ~halves deploy build time and makes the md5 sanity check meaningful (same artifact on both sides).

### #44 — CHANGELOG.md empty placeholders  · `ci` + `docs`
Root cause: `auto-version.yml` injected **empty** `### Added/Changed/Fixed` placeholders into `CHANGELOG.md` while the real notes only went to GitHub Releases.
- **New `scripts/generate-changelog-entries.sh`** — single source of truth that classifies conventional commits into Keep-a-Changelog sections (excludes automated bump-commits).
- `auto-version.yml` and `bump-version.sh` now **populate `CHANGELOG.md` from it**, and the GitHub-Release-notes step **reuses the same script** (removed ~55 lines of duplicated classification logic — true DRY/SSOT).
- **New `scripts/backfill-changelog.sh`** — reconciled **26** historical empty sections from their GitHub Releases, deduplicated the repeated `0.13.0`, reordered (`[Unreleased]` first, versions descending), and placeholdered the 3 versions with no release body.

### #36 — Circuit Breaker default-off undocumented  · `docs`
Documented in `CHANGELOG.md` **v0.12.0**. Note: verified the CB was actually introduced in **0.12.0** (commit `fbd3807`), **not** 0.13.0 as the issue assumed, and used the **real** env vars `CB_ENABLED` / `CB_THRESHOLD` / `CB_RECOVERY_SECS` (the issue's `CB_RESET_SECS`/`CB_HALF_OPEN_MAX` don't exist).

### Bonus — lockfile divergence + build/dev hygiene
- `auto-version.yml` now runs `cargo update --workspace` and **commits `Cargo.lock`** on bump → fixes the perpetual `M Cargo.lock` (the committed lock was stale at `0.19.0` vs `Cargo.toml` `0.19.1`).
- Release profile `lto = true` → **`lto = "thin"`** — fat LTO OOM'd local 13 GB builds; thin LTO peaks ~7.3 GB, builds in 2m36s, 9.6 MB binary.
- **New `scripts/dev-test.sh`** — isolated test runner (`:8316`, separate `CARGO_TARGET_DIR`, port guardrail) that never touches production `:8315` nor triggers the binary watcher.

## Validation
- **shellcheck**: all new/modified scripts clean (deploy.sh's 2 warnings are pre-existing `SC2034`, outside the changed lines).
- `cargo fmt --check` ✓ · `cargo clippy -- -D warnings` ✓ · **`cargo test`: 301 passed, 0 failed**.
- `auto-version.yml`: valid YAML; duplicated inline release-notes logic fully removed (0 references).
- `CHANGELOG.md`: 33 versions, **no duplicates**, no malformed `---` separators, no triple blank lines, `[Unreleased]` first.
- Production (`:8315`) and the systemd watcher were **not touched** during this work.

## Notes for the reviewer
- All commits are `ci` / `docs` / `chore` → the post-commit analyzer confirms **no auto-version bump** will be triggered on merge.
- `.cargo/config.toml` (a local `gcc`+`mold` linker override) is intentionally **excluded** from this PR — committing it would break CI (`mold` is not installed on the runners).
- ⚠️ **Do not merge without explicit owner confirmation.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Completed and backfilled changelog with full historical release notes from versions 0.5.0 onwards.

* **Performance**
  * Optimized release builds for reduced binary size through improved compilation settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->