### PR TITLE
test: regression test for --config path persisting through hot-reload (closes #45)

### DIFF
--- a/src/watcher_test.rs
+++ b/src/watcher_test.rs
@@ -415,3 +415,37 @@ fn cooldown_duration_is_15s_and_greater_than_debounce() {
 }
 
 use std::sync::Arc;
+
+// ---------------------------------------------------------------------------
+// #45 regression: a custom --config path must survive hot-reload
+// ---------------------------------------------------------------------------
+
+#[test]
+fn reload_preserves_custom_config_path() {
+    // Regression for #45: when launched with `--config /custom.env`, the SIGHUP
+    // handler and the file watcher both call Config::reload(.., config_path).
+    // reload MUST preserve that custom path in the returned config so the *next*
+    // reload keeps using it instead of silently reverting to the default
+    // ~/.nexus-ai-gateway.env (the original bug: the path was discarded forever).
+    use crate::config::Config;
+    use std::io::Write;
+
+    // A minimal valid env file at a non-default custom path.
+    let path = std::env::temp_dir().join(format!("nexus45-{}-{}.env", std::process::id(), line!()));
+    {
+        let mut f = std::fs::File::create(&path).expect("create temp env file");
+        writeln!(f, "UPSTREAM_BASE_URL=http://localhost:11434").unwrap();
+        writeln!(f, "UPSTREAM_API_KEY=test-key").unwrap();
+    }
+
+    let cfg = Config::reload(false, false, None, Some(path.clone()))
+        .expect("reload with a custom config path should succeed");
+
+    assert_eq!(
+        cfg.config_path,
+        Some(path.clone()),
+        "reload must preserve the custom --config path for subsequent SIGHUP/watcher reloads (#45)"
+    );
+
+    let _ = std::fs::remove_file(&path);
+}


### PR DESCRIPTION
## Summary

**Issue #45 was already fixed in the codebase** — this PR adds the missing **behavioral regression test** and closes the issue.

Closes #45.

## Finding

While preparing to implement #45 (`--config` path ignored by hot-reload), I verified the current `main` and found the fix is **already present**, landed in commit `67f0ab8` (the "Global fix · Issue #88") with `fix#52` annotations:

| Component | State | Location |
|-----------|-------|----------|
| `Config.config_path: Option<PathBuf>` field | ✅ present | `src/config.rs:110` |
| `from_env_with_path` stores the custom path | ✅ `config_path: stored_config_path` | `src/config.rs:845` |
| `reload(.., config_path)` accepts **and preserves** it | ✅ `config.config_path = config_path` | `src/config.rs:889-895` |
| **SIGHUP handler** uses the custom path | ✅ `reload_config.load().config_path` | `src/main.rs:367-368` |
| **File watcher** uses the custom path | ✅ `watch_config.load().config_path` | `src/main.rs:503-504` |

So the original bug ("custom `--config` path discarded forever, hot-reload reverts to the default") is resolved.

## What this PR adds

The existing `config_path` tests in `src/watcher_test.rs` are **structural only** — they assert the function signature, the struct field, and the default value. None of them exercise the actual **behavior** the bug was about.

This PR adds `reload_preserves_custom_config_path`, a behavioral regression test that:
1. Writes a minimal valid env file at a non-default custom path,
2. Calls `Config::reload(false, false, None, Some(custom_path))`,
3. Asserts the returned `config.config_path == Some(custom_path)`.

This locks in the fix so a future refactor cannot silently reintroduce the "path lost on reload" regression.

## Validation
- `cargo test reload_preserves_custom_config_path` ✓ (new test passes)
- `cargo fmt --check` ✓ · `cargo clippy -- -D warnings` ✓ · full suite green, 0 failures.
- Hermetic: the test uses a unique temp file (pid + line), does not mutate the global environment, and the `config_path` assertion is independent of machine-specific env files.

## Notes
- This PR is intentionally **separate** from the CI/CD cluster PR (#91, which closes #36/#41/#44) — #45 is a different domain (runtime config) and shares no files.
- Commit type `test:` → no auto-version bump on merge.
- ⚠️ **Do not merge without explicit owner confirmation.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
