### PR TITLE
fix: wire P6 edit-rescue/metrics + sanitize cross-backend tool_use ids (#93, #90 Part A)

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -11,6 +11,7 @@ mod setup;
 mod str_utils;
 mod telemetry;
 mod tokenizer;
+mod tool_id;
 mod transform;
 mod watcher;
 mod web_fetch;

--- a/src/proxy/edit_metrics.rs
+++ b/src/proxy/edit_metrics.rs
@@ -8,7 +8,6 @@ use std::path::Path;
 use std::time::Duration;
 
 /// Outcome of an Edit tool operation
-#[allow(dead_code)] // TODO: Wire into streaming.rs pipeline (Issue #88)
 #[derive(Debug, Clone)]
 pub enum EditOutcome {
     Success,
@@ -17,7 +16,6 @@ pub enum EditOutcome {
 }
 
 /// Classification of Edit failure types
-#[allow(dead_code)] // TODO: Wire into streaming.rs pipeline (Issue #88)
 #[derive(Debug, Clone)]
 pub enum EditFailureType {
     StringNotFound,
@@ -29,7 +27,6 @@ pub enum EditFailureType {
 }
 
 impl EditFailureType {
-    #[allow(dead_code)] // TODO: Wire into streaming.rs pipeline (Issue #88)
     pub fn as_str(&self) -> &'static str {
         match self {
             Self::StringNotFound => "string_not_found",
@@ -43,7 +40,6 @@ impl EditFailureType {
 }
 
 /// Records an Edit outcome with Prometheus metrics.
-#[allow(dead_code)] // TODO: Wire into streaming.rs pipeline (Issue #88)
 pub fn record_edit_outcome(result: &EditOutcome, file_path: &str, latency: Duration) {
     let file_basename =
         Path::new(file_path).file_name().and_then(|n| n.to_str()).unwrap_or("unknown");
@@ -67,13 +63,11 @@ pub fn record_edit_outcome(result: &EditOutcome, file_path: &str, latency: Durat
 }
 
 /// Records an Edit rescue attempt outcome.
-#[allow(dead_code)] // TODO: Wire into streaming.rs pipeline (Issue #88)
 pub fn record_edit_rescue_outcome(outcome: &str) {
     counter!("nexus_edit_rescue_total", "result" => outcome.to_string()).increment(1);
 }
 
 /// Classifies an Edit error message into its failure type.
-#[allow(dead_code)] // TODO: Wire into streaming.rs pipeline (Issue #88)
 pub fn classify_edit_error(error_msg: &str) -> EditFailureType {
     if error_msg.contains("not unique") {
         EditFailureType::NotUnique

--- a/src/proxy/edit_rescue.rs
+++ b/src/proxy/edit_rescue.rs
@@ -9,7 +9,10 @@
 //! - The fuzzy match is unique (or replace_all=true)
 //! - Zero risk of data loss — original error returned on any ambiguity
 
+use crate::models::anthropic::{self, ContentBlock, MessageContent};
+use std::collections::HashMap;
 use std::path::Path;
+use std::time::{Duration, Instant};
 use tokio::fs;
 
 // Note: Since the Unicode sanitizer already ran (P1), source files should
@@ -20,7 +23,6 @@ use tokio::fs;
 
 /// Bidirectional Unicode <-> ASCII mapping for fuzzy Edit matching.
 /// Each entry maps a Unicode character to its ASCII equivalent.
-#[allow(dead_code)] // TODO: Wire into streaming.rs pipeline (Issue #88)
 const UNICODE_ASCII_MAP: &[(&str, &str)] = &[
     ("\u{2192}", "->"),                // RIGHTWARDS ARROW
     ("\u{23F1}\u{FE0F}", "[TIMEOUT]"), // STOPWATCH + VS16
@@ -36,7 +38,6 @@ const UNICODE_ASCII_MAP: &[(&str, &str)] = &[
 ];
 
 /// Parameters extracted from an Edit tool call
-#[allow(dead_code)] // TODO: Wire into streaming.rs pipeline (Issue #88)
 #[derive(Debug)]
 pub struct EditParams {
     pub file_path: String,
@@ -46,7 +47,6 @@ pub struct EditParams {
 }
 
 /// Result of an Edit rescue attempt
-#[allow(dead_code)] // TODO: Wire into streaming.rs pipeline (Issue #88)
 #[derive(Debug, PartialEq)]
 pub enum EditRescueResult {
     /// Fuzzy match succeeded — file was written with the new content
@@ -61,7 +61,6 @@ pub enum EditRescueResult {
 /// Returns Some(NotRescuable) if no variant matched.
 ///
 /// This is ASYNC — reads/writes files via tokio::fs without blocking.
-#[allow(dead_code)] // TODO: Wire into streaming.rs pipeline (Issue #88)
 pub async fn maybe_rescue_edit(
     edit_params: &EditParams,
     error_msg: &str,
@@ -157,7 +156,6 @@ pub async fn maybe_rescue_edit(
 }
 
 /// Generates multiple normalized variants of the search string.
-#[allow(dead_code)] // TODO: Wire into streaming.rs pipeline (Issue #88)
 fn generate_fuzzy_variants(original: &str) -> Vec<String> {
     let mut variants = vec![original.to_string()];
 
@@ -183,7 +181,6 @@ fn generate_fuzzy_variants(original: &str) -> Vec<String> {
 }
 
 /// Attempts string replacement, returns new content if old string is found.
-#[allow(dead_code)] // TODO: Wire into streaming.rs pipeline (Issue #88)
 fn try_replace(content: &str, old: &str, new: &str, replace_all: bool) -> Option<String> {
     if !content.contains(old) {
         return None;
@@ -195,6 +192,124 @@ fn try_replace(content: &str, old: &str, new: &str, replace_all: bool) -> Option
         let mut result = content.to_string();
         result.replace_range(idx..idx + old.len(), new);
         Some(result)
+    }
+}
+
+/// Parse Edit parameters from a `tool_use` input JSON. Returns `None` when the
+/// input is not an Edit (missing `file_path` / `old_string` / `new_string`).
+fn parse_edit_params(input: &serde_json::Value) -> Option<EditParams> {
+    Some(EditParams {
+        file_path: input.get("file_path")?.as_str()?.to_string(),
+        old_string: input.get("old_string")?.as_str()?.to_string(),
+        new_string: input.get("new_string")?.as_str()?.to_string(),
+        replace_all: input.get("replace_all").and_then(|v| v.as_bool()).unwrap_or(false),
+    })
+}
+
+/// Flatten a `tool_result` content into plain text (for error-message matching).
+fn tool_result_text(content: &anthropic::ToolResultContent) -> String {
+    match content {
+        anthropic::ToolResultContent::Text(s) => s.clone(),
+        anthropic::ToolResultContent::Blocks(blocks) => blocks
+            .iter()
+            .filter_map(|b| match b {
+                ContentBlock::Text { text, .. } => Some(text.clone()),
+                _ => None,
+            })
+            .collect::<Vec<_>>()
+            .join("\n"),
+    }
+}
+
+/// Request-side Edit-rescue hook (Issue #88 P6 / Issue #93).
+///
+/// Both the Edit `tool_use` (file_path/old_string/new_string) and the failing
+/// `tool_result` ("String to replace not found") live in the inbound request, so the
+/// rescue is stateless: it indexes Edit `tool_use` params by id, then inspects only
+/// the **last** message's tool_results (the current turn — replayed history is skipped
+/// to avoid redundant rescues and double-counted telemetry). On a unique fuzzy Unicode
+/// match, `maybe_rescue_edit` rewrites the file on disk (guarded to `src/` within the
+/// cwd) and the failing `tool_result` is rewritten to success so the model does not loop.
+pub async fn rescue_request_edits(req: &mut anthropic::AnthropicRequest) {
+    use crate::proxy::edit_metrics::{
+        classify_edit_error, record_edit_outcome, record_edit_rescue_outcome, EditOutcome,
+    };
+
+    // 1. Index Edit tool_use params by id across the whole conversation.
+    let mut edits: HashMap<String, EditParams> = HashMap::new();
+    for msg in &req.messages {
+        if let MessageContent::Blocks(blocks) = &msg.content {
+            for b in blocks {
+                if let ContentBlock::ToolUse { id, input, .. } = b {
+                    if let Some(p) = parse_edit_params(input) {
+                        edits.insert(id.clone(), p);
+                    }
+                }
+            }
+        }
+    }
+    if edits.is_empty() {
+        return;
+    }
+
+    // 2. Only the last message is "new" this turn; skip replayed history.
+    let last = match req.messages.last_mut() {
+        Some(m) => m,
+        None => return,
+    };
+    let blocks = match &mut last.content {
+        MessageContent::Blocks(b) => b,
+        MessageContent::Text(_) => return,
+    };
+
+    for block in blocks.iter_mut() {
+        if let ContentBlock::ToolResult { tool_use_id, content, is_error } = block {
+            let id = tool_use_id.clone();
+            let params = match edits.get(&id) {
+                Some(p) => p,
+                None => continue, // not an Edit tool_result
+            };
+
+            if *is_error != Some(true) {
+                record_edit_outcome(&EditOutcome::Success, &params.file_path, Duration::ZERO);
+                continue;
+            }
+
+            let err_text = tool_result_text(content);
+            let started = Instant::now();
+            match maybe_rescue_edit(params, &err_text).await {
+                Some(EditRescueResult::Rescued { .. }) => {
+                    tracing::info!("Edit rescue: rewrote failing tool_result {} to success", id);
+                    *content = anthropic::ToolResultContent::Text(
+                        "Edit applied successfully (rescued by NEXUS Unicode fuzzy match)."
+                            .to_string(),
+                    );
+                    *is_error = Some(false);
+                    record_edit_outcome(
+                        &EditOutcome::Rescued,
+                        &params.file_path,
+                        started.elapsed(),
+                    );
+                    record_edit_rescue_outcome("rescued");
+                }
+                Some(EditRescueResult::NotRescuable { .. }) => {
+                    record_edit_outcome(
+                        &EditOutcome::Failed(classify_edit_error(&err_text)),
+                        &params.file_path,
+                        started.elapsed(),
+                    );
+                    record_edit_rescue_outcome("not_rescuable");
+                }
+                None => {
+                    // An Edit error, but not "String to replace not found" — record only.
+                    record_edit_outcome(
+                        &EditOutcome::Failed(classify_edit_error(&err_text)),
+                        &params.file_path,
+                        started.elapsed(),
+                    );
+                }
+            }
+        }
     }
 }
 
@@ -256,5 +371,148 @@ mod tests {
         let content = "aaa bbb aaa";
         let result = try_replace(content, "aaa", "ccc", true);
         assert_eq!(result, Some("ccc bbb ccc".to_string()));
+    }
+
+    // ---- Issue #88 P6 / #93: request-side rescue-hook wiring ----
+
+    fn req(v: serde_json::Value) -> anthropic::AnthropicRequest {
+        serde_json::from_value(v).expect("valid AnthropicRequest JSON")
+    }
+
+    /// (is_error, flattened text) of the first tool_result in the last message.
+    fn last_tool_result(r: &anthropic::AnthropicRequest) -> (Option<bool>, String) {
+        match &r.messages.last().expect("at least one message").content {
+            MessageContent::Blocks(blocks) => {
+                for blk in blocks {
+                    if let ContentBlock::ToolResult { is_error, content, .. } = blk {
+                        return (*is_error, tool_result_text(content));
+                    }
+                }
+                panic!("no tool_result block in last message");
+            }
+            MessageContent::Text(_) => panic!("last message is text, not blocks"),
+        }
+    }
+
+    #[test]
+    fn parse_edit_params_extracts_fields_and_rejects_partial() {
+        let full = serde_json::json!({
+            "file_path": "src/x.rs", "old_string": "a", "new_string": "b", "replace_all": true
+        });
+        let p = parse_edit_params(&full).expect("full Edit input parses");
+        assert_eq!(p.file_path, "src/x.rs");
+        assert_eq!(p.old_string, "a");
+        assert_eq!(p.new_string, "b");
+        assert!(p.replace_all);
+
+        // replace_all defaults to false when omitted.
+        let no_flag = serde_json::json!({"file_path":"f","old_string":"a","new_string":"b"});
+        assert!(!parse_edit_params(&no_flag).unwrap().replace_all);
+
+        // Missing a required field => None (not an Edit).
+        let partial = serde_json::json!({"file_path":"f","old_string":"a"});
+        assert!(parse_edit_params(&partial).is_none());
+    }
+
+    #[test]
+    fn tool_result_text_flattens_text_and_blocks() {
+        let t = anthropic::ToolResultContent::Text("hello".to_string());
+        assert_eq!(tool_result_text(&t), "hello");
+
+        let b = anthropic::ToolResultContent::Blocks(vec![
+            ContentBlock::Text { text: "line1".to_string(), cache_control: None },
+            ContentBlock::Text { text: "line2".to_string(), cache_control: None },
+        ]);
+        assert_eq!(tool_result_text(&b), "line1\nline2");
+    }
+
+    #[tokio::test]
+    async fn rescue_is_noop_without_edit_tool_use() {
+        let mut r = req(serde_json::json!({
+            "model": "claude-sonnet-4-6",
+            "max_tokens": 100,
+            "messages": [{ "role": "user", "content": "hello, no tools here" }]
+        }));
+        let before = serde_json::to_value(&r).unwrap();
+        rescue_request_edits(&mut r).await;
+        let after = serde_json::to_value(&r).unwrap();
+        assert_eq!(before, after, "request without Edit tool_use must be untouched");
+    }
+
+    #[tokio::test]
+    async fn rescue_preserves_unrescuable_error() {
+        // Edit tool_use + a failing tool_result whose error is NOT the rescuable
+        // "String to replace not found" => maybe_rescue_edit returns None => preserved.
+        let mut r = req(serde_json::json!({
+            "model": "m", "max_tokens": 10,
+            "messages": [
+                { "role": "assistant", "content": [
+                    { "type": "tool_use", "id": "ed_1", "name": "Edit",
+                      "input": { "file_path": "src/x.rs", "old_string": "a", "new_string": "b" } }
+                ]},
+                { "role": "user", "content": [
+                    { "type": "tool_result", "tool_use_id": "ed_1",
+                      "content": "Some unrelated failure", "is_error": true }
+                ]}
+            ]
+        }));
+        rescue_request_edits(&mut r).await;
+        let (is_error, text) = last_tool_result(&r);
+        assert_eq!(is_error, Some(true), "non-rescuable error must remain an error");
+        assert_eq!(text, "Some unrelated failure", "content must be unchanged");
+    }
+
+    #[tokio::test]
+    async fn rescue_respects_path_guard_outside_src() {
+        // Error IS rescuable text, but file_path is outside src/ within cwd =>
+        // maybe_rescue_edit returns NotRescuable => is_error stays true (no false rescue).
+        let mut r = req(serde_json::json!({
+            "model": "m", "max_tokens": 10,
+            "messages": [
+                { "role": "assistant", "content": [
+                    { "type": "tool_use", "id": "ed_2", "name": "Edit",
+                      "input": { "file_path": "/tmp/outside.rs", "old_string": "foo", "new_string": "bar" } }
+                ]},
+                { "role": "user", "content": [
+                    { "type": "tool_result", "tool_use_id": "ed_2",
+                      "content": "String to replace not found: foo", "is_error": true }
+                ]}
+            ]
+        }));
+        rescue_request_edits(&mut r).await;
+        let (is_error, _) = last_tool_result(&r);
+        assert_eq!(is_error, Some(true), "path-guard rejection must not flip is_error");
+    }
+
+    #[tokio::test]
+    async fn rescue_only_processes_last_message() {
+        // A rescuable-looking Edit error sits in a NON-last message; the last message
+        // is plain text. The hook inspects only the last message, so the historical
+        // error must remain untouched (history is never rescued / double-counted).
+        let mut r = req(serde_json::json!({
+            "model": "m", "max_tokens": 10,
+            "messages": [
+                { "role": "assistant", "content": [
+                    { "type": "tool_use", "id": "ed_3", "name": "Edit",
+                      "input": { "file_path": "src/x.rs", "old_string": "foo", "new_string": "bar" } }
+                ]},
+                { "role": "user", "content": [
+                    { "type": "tool_result", "tool_use_id": "ed_3",
+                      "content": "String to replace not found: foo", "is_error": true }
+                ]},
+                { "role": "assistant", "content": "ok, moving on" }
+            ]
+        }));
+        rescue_request_edits(&mut r).await;
+        // Inspect the historical (index 1) tool_result — must still be an error.
+        match &r.messages[1].content {
+            MessageContent::Blocks(blocks) => match &blocks[0] {
+                ContentBlock::ToolResult { is_error, .. } => {
+                    assert_eq!(*is_error, Some(true), "historical error must be untouched");
+                }
+                _ => panic!("expected tool_result"),
+            },
+            _ => panic!("expected blocks"),
+        }
     }
 }

--- a/src/proxy/mod.rs
+++ b/src/proxy/mod.rs
@@ -187,7 +187,7 @@ pub async fn proxy_handler(
     Extension(telemetry_ctx): Extension<Option<crate::telemetry::TelemetryContext>>,
     headers: HeaderMap, // Issue #35 F4: Extract client headers for forwarding
     ConnectInfo(client_addr): ConnectInfo<std::net::SocketAddr>,
-    Json(req): Json<anthropic::AnthropicRequest>,
+    Json(mut req): Json<anthropic::AnthropicRequest>,
 ) -> ProxyResult<Response> {
     // S3: Track active connections
     let _conn_guard = ConnectionGuard::new();
@@ -255,6 +255,12 @@ pub async fn proxy_handler(
             serde_json::to_string_pretty(&req).unwrap_or_default()
         );
     }
+
+    // Issue #88 P6 / #93: rescue Edit failures caused by CC Unicode normalization
+    // before forwarding upstream — rewrites a unique fuzzy match on disk (guarded to
+    // src/ within cwd) and turns the failing tool_result into success so the model
+    // does not loop on an already-corrected file.
+    crate::proxy::edit_rescue::rescue_request_edits(&mut req).await;
 
     // Issue #35 F9: Pre-resolve upstream_name for conditional chat_template_kwargs
     let (_, upstream_name_pre) = transform::resolve_model_and_upstream(&req.model, true, &config);

--- a/src/proxy/streaming.rs
+++ b/src/proxy/streaming.rs
@@ -525,7 +525,10 @@ pub(crate) fn create_sse_stream(
                                                         yield Ok(Bytes::from(sse_data));
                                                         content_index += 1;
                                                     }
-                                                    tool_call_id = Some(id.clone());
+                                                    // Issue #90: sanitize at the source so both the
+                                                    // emitted tool_use.id and the web_fetch buffer are valid.
+                                                    tool_call_id =
+                                                        Some(crate::tool_id::sanitize_tool_id(id, content_index as usize));
                                                     tool_call_args.clear();
                                                     tool_calls_emitted = true;
                                                 }
@@ -547,7 +550,7 @@ pub(crate) fn create_sse_stream(
                                                                 "index": content_index,
                                                                 "content_block": {
                                                                     "type": "tool_use",
-                                                                    "id": tool_call_id.clone().unwrap_or_default(),
+                                                                    "id": tool_call_id.clone().unwrap_or_else(|| format!("toolu_{content_index}")),
                                                                     "name": name
                                                                 }
                                                             });

--- a/src/tool_id.rs
+++ b/src/tool_id.rs
@@ -1,0 +1,156 @@
+//! Sanitization of upstream tool-call ids into the charset the Anthropic API accepts.
+//!
+//! Anthropic validates every `tool_use.id` (and `tool_result.tool_use_id`) against
+//! `^[A-Za-z0-9_-]+$` (the base64url alphabet, |V| = 64). Some OpenAI-compatible
+//! upstreams (NIM / vLLM) emit ids such as `functions.<tool>:<idx>` (e.g.
+//! `functions.Bash:0`) which contain `.` and `:`. Claude Code stores those ids in
+//! its transcript and replays them; when a conversation is later opened against the
+//! Anthropic-direct backend, the strict server-side validator rejects the whole
+//! request with HTTP 400. NEXUS therefore sanitizes every id it emits to Claude Code.
+//!
+//! See `docs/Investigacion-tool-use-id-cross-backend/` (Issue #90, Part A).
+
+/// `true` if `s` already matches `^[A-Za-z0-9_-]+$` (non-empty, valid charset only).
+#[inline]
+fn is_valid_tool_id(s: &str) -> bool {
+    !s.is_empty() && s.bytes().all(|b| b.is_ascii_alphanumeric() || b == b'_' || b == b'-')
+}
+
+/// Returns a tool-call id guaranteed to satisfy Anthropic's `^[A-Za-z0-9_-]+$`.
+///
+/// Properties (see entregable 03): deterministic, idempotent, length-preserving for
+/// non-empty inputs, and injective over the real `functions.<tool>:<idx>` format.
+///
+/// - If `raw` is already valid, it is returned unchanged (the ~99.86% fast path).
+/// - Otherwise every byte outside `[A-Za-z0-9_-]` is replaced by `_`.
+/// - If `raw` is empty, a deterministic `toolu_<fallback_index>` is generated so the
+///   `+` (non-empty) rule holds. `fallback_index` is only consulted for empty input.
+pub fn sanitize_tool_id(raw: &str, fallback_index: usize) -> String {
+    if is_valid_tool_id(raw) {
+        return raw.to_string();
+    }
+    if raw.is_empty() {
+        return format!("toolu_{fallback_index}");
+    }
+    raw.chars()
+        .map(|c| if c.is_ascii_alphanumeric() || c == '_' || c == '-' { c } else { '_' })
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use regex::Regex;
+
+    fn valid(s: &str) -> bool {
+        Regex::new(r"^[A-Za-z0-9_-]+$").unwrap().is_match(s)
+    }
+
+    #[test]
+    fn passthrough_valid_openai_id() {
+        assert_eq!(sanitize_tool_id("call_abc123XYZ", 0), "call_abc123XYZ");
+    }
+
+    #[test]
+    fn passthrough_valid_nim_id() {
+        assert_eq!(
+            sanitize_tool_id("chatcmpl-tool-81c39bc66a7f5fe7", 0),
+            "chatcmpl-tool-81c39bc66a7f5fe7"
+        );
+    }
+
+    #[test]
+    fn passthrough_valid_anthropic_id() {
+        assert_eq!(sanitize_tool_id("toolu_01ABCdef", 0), "toolu_01ABCdef");
+    }
+
+    #[test]
+    fn replaces_dot_and_colon() {
+        assert_eq!(sanitize_tool_id("functions.Bash:0", 0), "functions_Bash_0");
+        assert_eq!(sanitize_tool_id("functions.Read:18", 0), "functions_Read_18");
+    }
+
+    #[test]
+    fn handles_all_29_real_violators() {
+        // The 29 unique invalid ids observed in real transcripts were all of the
+        // form functions.<ToolName>:<index>. Each must become valid.
+        let names = ["Agent", "Bash", "Read"];
+        for name in names {
+            for idx in 0..25 {
+                let raw = format!("functions.{name}:{idx}");
+                let out = sanitize_tool_id(&raw, 0);
+                assert!(valid(&out), "sanitized id must be valid: {raw} -> {out}");
+                assert!(!out.contains('.') && !out.contains(':'));
+            }
+        }
+    }
+
+    #[test]
+    fn empty_id_gets_fallback() {
+        assert_eq!(sanitize_tool_id("", 3), "toolu_3");
+        assert!(valid(&sanitize_tool_id("", 0)));
+    }
+
+    #[test]
+    fn output_always_matches_pattern() {
+        // Property (R1): for arbitrary inputs the output is always accepted.
+        let cases = [
+            "functions.Bash:0",
+            "a.b:c/d+e=f",
+            "tool\u{2192}x",
+            "with space",
+            "",
+            "UPPER_lower-123",
+            "::::",
+            ".",
+        ];
+        for (i, c) in cases.iter().enumerate() {
+            assert!(valid(&sanitize_tool_id(c, i)), "failed for {c:?}");
+        }
+    }
+
+    #[test]
+    fn is_idempotent() {
+        for c in ["functions.Bash:0", "call_abc", "", "a:b.c"] {
+            let once = sanitize_tool_id(c, 1);
+            let twice = sanitize_tool_id(&once, 1);
+            assert_eq!(once, twice, "S must be idempotent for {c:?}");
+        }
+    }
+
+    #[test]
+    fn preserves_length_for_nonempty() {
+        // Length-preserving for non-empty inputs => never exceeds an already-accepted length.
+        for c in ["functions.Bash:0", "a.b:c", "call_x"] {
+            assert_eq!(sanitize_tool_id(c, 0).len(), c.len(), "length must be preserved for {c:?}");
+        }
+    }
+
+    #[test]
+    fn pairing_invariant_preserved() {
+        // tool_use.id and tool_result.tool_use_id carry the same string; a deterministic
+        // function maps both identically, preserving the pairing.
+        let id = "functions.Bash:7";
+        assert_eq!(sanitize_tool_id(id, 0), sanitize_tool_id(id, 99));
+    }
+
+    #[test]
+    fn non_ascii_replaced() {
+        let out = sanitize_tool_id("tool\u{2192}id", 0);
+        assert_eq!(out, "tool_id");
+        assert!(valid(&out));
+    }
+
+    #[test]
+    fn injective_on_real_format() {
+        // Distinct functions.<tool>:<idx> ids never collide after sanitization.
+        use std::collections::HashSet;
+        let mut seen = HashSet::new();
+        for name in ["Bash", "Read", "Agent"] {
+            for idx in 0..25 {
+                let out = sanitize_tool_id(&format!("functions.{name}:{idx}"), 0);
+                assert!(seen.insert(out.clone()), "collision on {out}");
+            }
+        }
+    }
+}

--- a/src/transform.rs
+++ b/src/transform.rs
@@ -288,7 +288,8 @@ fn convert_message(msg: anthropic::Message) -> ProxyResult<Vec<openai::Message>>
                     }
                     anthropic::ContentBlock::ToolUse { id, name, input } => {
                         tool_calls.push(openai::ToolCall {
-                            id,
+                            // Issue #90: idempotent defense-in-depth on the request path.
+                            id: crate::tool_id::sanitize_tool_id(&id, 0),
                             call_type: "function".to_string(),
                             function: openai::FunctionCall {
                                 name,
@@ -324,7 +325,7 @@ fn convert_message(msg: anthropic::Message) -> ProxyResult<Vec<openai::Message>>
                             role: "tool".to_string(),
                             content: Some(openai::MessageContent::Text(text_content)),
                             tool_calls: None,
-                            tool_call_id: Some(tool_use_id),
+                            tool_call_id: Some(crate::tool_id::sanitize_tool_id(&tool_use_id, 0)),
                             name: None,
                         });
                     }
@@ -495,13 +496,14 @@ pub fn openai_to_anthropic(
 
     // Add tool calls if present
     if let Some(tool_calls) = &choice.message.tool_calls {
-        for tool_call in tool_calls {
+        for (i, tool_call) in tool_calls.iter().enumerate() {
             let input: Value =
                 serde_json::from_str(&tool_call.function.arguments).unwrap_or_else(|_| json!({}));
 
             content.push(anthropic::ResponseContent::ToolUse {
                 content_type: "tool_use".to_string(),
-                id: tool_call.id.clone(),
+                // Issue #90: sanitize ids like `functions.Bash:0` to Anthropic's ^[A-Za-z0-9_-]+$.
+                id: crate::tool_id::sanitize_tool_id(&tool_call.id, i),
                 name: tool_call.function.name.clone(),
                 input,
             });


### PR DESCRIPTION
## Summary

Two tightly-related cross-backend replay fixes, in atomic commits:

1. **P6 gap (Issue #93)** — `edit_rescue.rs` + `edit_metrics.rs` shipped in PR #89 but were **never called** (12 `#[allow(dead_code)]` markers). This wires them into `proxy_handler`.
2. **Issue #90 Part A** — sanitize invalid `tool_use.id` / `tool_result.tool_use_id` that break the cross-backend replay to Anthropic-direct with HTTP 400.

Both addressed first the **P6 gap** (per the user-requested ordering), then #90 Part A, on a single branch.

---

## Commit A — `feat: sanitize cross-backend tool_use ids (Issue #90 Part A)`

NIM/vLLM emit ids such as `functions.Bash:0`; the `.` and `:` violate Anthropic's `^[A-Za-z0-9_-]+$`. Claude Code replays them verbatim, so re-opening the transcript against the Anthropic-direct backend rejects the whole request (HTTP 400).

- New `src/tool_id.rs::sanitize_tool_id` — deterministic, idempotent, length-preserving for non-empty input, injective over the real `functions.<tool>:<idx>` format.
- Applied at all four id boundaries:
  - **B1** non-streaming response `tool_use.id` (`src/transform.rs`)
  - **B2** streaming response `tool_use.id` (`src/proxy/streaming.rs`)
  - **B3** request `tool_use.id` (`src/transform.rs`)
  - **B4** request `tool_result.tool_use_id` (`src/transform.rs`)
- Empty ids → deterministic `toolu_<index>` fallback (keeps the non-empty rule; preserves `tool_use`/`tool_result` pairing).
- **12 regex-validated unit tests.**

## Commit B — `fix: wire edit-rescue + edit-metrics into request pipeline (Issue #93)`

New request-side hook `rescue_request_edits` (`src/proxy/edit_rescue.rs`):

- Indexes Edit `tool_use` params (`file_path` / `old_string` / `new_string`) by id across the conversation.
- Inspects **only the last message's** `tool_result`s (the current turn) — replayed history is skipped to avoid redundant rescues and **double-counted telemetry**.
- On a unique fuzzy-Unicode match, `maybe_rescue_edit` rewrites the file on disk (guarded to `src/` within the cwd) and rewrites the failing `tool_result` to success so the model does not loop on an already-corrected file.
- Records `EditOutcome` (Success / Failed / Rescued) + rescue-outcome Prometheus metrics.
- Wired into `proxy_handler` **before** the `anthropic → openai` transform, so the upstream receives the corrected request.
- **Removed all 12 `#[allow(dead_code)]` markers.**
- **6 new wiring tests** (no-op without Edit, unrescuable error preserved, path-guard outside `src/`, last-message-only, `parse_edit_params`, `tool_result_text`).

---

## Test plan

- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -- -D warnings` (project gate) — exit 0, no warnings in changed files
- [x] `cargo test` — **320 passed, 0 failed** (313 unit + 4 integration + 3 version-sync)
- [x] `edit_rescue::tests` — 13 passed (6 new); `tool_id::tests` — 12 passed
- [x] Production `systemd` release binary untouched (debug-only build; release path unchanged)

## Scope notes

- **Closes #93** (P6 gap fully resolved).
- **Addresses #90 Part A.** Part B (empty-`thinking` signature / ARB reasoning methodology) is a documented, separate follow-up and is intentionally **not** in this PR.
- `.cargo/config.toml` (a local `gcc`+`mold` linker override, pre-existing and machine-specific) is intentionally **excluded** to keep the PR scoped and avoid forcing a linker on CI/other contributors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added automatic recovery mechanism for edit tool failures using fuzzy matching to correct minor formatting issues.

* **Bug Fixes**
  * Tool identifiers now sanitized to ensure compliance with required format specifications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->