### PR TITLE
fix: post-merge hook shebang to bash (Bad substitution on deploy)

### DIFF
--- a/scripts/hooks/post-merge
+++ b/scripts/hooks/post-merge
@@ -1,5 +1,9 @@
-#!/bin/sh
+#!/usr/bin/env bash
 # post-merge hook — Auto-sync after git pull that brings merge commits
+#
+# Shebang is bash (not /bin/sh): this hook uses bash parameter expansion such as
+# ${CARGO_MD5:0:8}. Under dash (/bin/sh) that raised "Bad substitution" on every
+# deploy (cosmetic — it only broke a confirmation echo, since there is no `set -e`).
 #
 # This hook fires AFTER "git pull" completes a merge (fast-forward or merge commit).
 # It solves the gap where:


### PR DESCRIPTION
## Summary

The post-merge auto-deploy hook (`scripts/hooks/post-merge`) used `#!/bin/sh` (dash) but
relies on the bash parameter expansion `${CARGO_MD5:0:8}`. Every merge-to-main deploy
therefore printed `post-merge: 111: Bad substitution`. With no `set -e`, the error was
**cosmetic** — the binary install + prod restart still completed — but it is deploy noise
and the `Binary installed: v… (md5: …)` confirmation line was lost.

Found while verifying the #100 (ARB) merge deploy on 2026-06-16.

## Change

- `scripts/hooks/post-merge`: `#!/bin/sh` → `#!/usr/bin/env bash`.
- Audited all five hooks: **only `post-merge` has bash-isms**; `commit-msg`, `post-commit`,
  `pre-commit`, `pre-push` are POSIX-clean and intentionally keep `#!/bin/sh`.

## Test plan

- [x] `bash -n scripts/hooks/post-merge` — clean.
- [x] `${CARGO_MD5:0:8}` expands correctly under bash (was `Bad substitution` under dash).
- [x] No Rust sources touched (pre-commit fmt/clippy gates not applicable).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal build hook script configuration for improved compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->