### PR TITLE
fix: Anthropic-parity for 3 bugs — rate-limit stream death, 2-second context overflow, CI version lag

### DIFF
--- a/.github/workflows/auto-version.yml
+++ b/.github/workflows/auto-version.yml
@@ -17,7 +17,13 @@ permissions:
 
 jobs:
   auto-version:
-    runs-on: ubuntu-latest
+    # Pinned to 22.04 (glibc 2.35) — NOT ubuntu-latest. ubuntu-latest is now 24.04
+    # (glibc 2.39), which produces a release binary that fails with
+    # "GLIBC_2.39 not found" on glibc < 2.39 hosts (Ubuntu/Pop!_OS 22.04, Debian 12,
+    # the prod deploy target). Building on 22.04 yields a binary that runs on
+    # glibc >= 2.35 (22.04 and everything newer), so the published Release asset is
+    # actually portable and the deploy can install it instead of rebuilding locally.
+    runs-on: ubuntu-22.04
     if: ${{ github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.event == 'push' }}
 
     steps:

--- a/scripts/sync-from-release.sh
+++ b/scripts/sync-from-release.sh
@@ -173,7 +173,11 @@ if ! systemctl --user restart "$SERVICE"; then
   exit 1
 fi
 sleep 3
-PORT="$(grep -E '^PORT=' "$ENV_FILE" 2>/dev/null | cut -d= -f2 | tr -d '[:space:]')"
+PORT="$(grep -E '^PORT=' "$ENV_FILE" 2>/dev/null | head -1 | cut -d= -f2- | tr -d '[:space:]')"
+PORT="${PORT%\"}"
+PORT="${PORT#\"}" # strip surrounding double quotes (PORT="8315")
+PORT="${PORT%\'}"
+PORT="${PORT#\'}" # strip surrounding single quotes (PORT='8315')
 PORT="${PORT:-8315}"
 if [ "$(curl -s --max-time 5 "http://localhost:${PORT}/health" 2>/dev/null)" = "OK" ]; then
   echo "✅ Deploy complete — v$LATEST_VER healthy on :$PORT"

--- a/scripts/sync-from-release.sh
+++ b/scripts/sync-from-release.sh
@@ -1,0 +1,183 @@
+#!/usr/bin/env bash
+# sync-from-release.sh — Reconcile the installed binary with the latest GitHub Release.
+#
+# Why this exists
+# ---------------
+# The post-merge git hook only rebuilds+installs when (a) you are ON the main branch
+# AND (b) a `git pull` brings a version change. The CI auto-version job bumps VERSION
+# in a separate "[skip ci]" commit AFTER the feature merge, so that bump is frequently
+# fetched while you are on a feature branch (or via a plain `git fetch`) — the hook
+# never fires and the installed binary lags the published Release (e.g. prod 0.21.0 vs
+# Release 0.21.1).
+#
+# This script reconciles the installed binary to the latest Release, independent of the
+# current branch, idempotently. It PREFERS the CI-built Release asset, but that asset is
+# only usable if it runs on this host's glibc — a CI runner newer than prod can emit a
+# binary that needs a newer glibc than prod has (the GLIBC_2.39 problem). So the script
+# verifies the downloaded binary actually executes here; if it does not (or the download
+# fails), it falls back to a local `cargo build --release`, which always links this
+# host's glibc.
+#
+# Default mode is DRY-RUN: it reports state and exits WITHOUT changing anything. Pass
+# --apply to act. It never touches prod unless every verification passes.
+set -uo pipefail
+
+REPO="enerBydev/nexus-ai-gateway"
+BINARY_NAME="nexus-ai-gateway"
+CARGO_BIN="$HOME/.cargo/bin/$BINARY_NAME"
+LOCAL_BIN="$HOME/.local/bin/$BINARY_NAME"
+ENV_FILE="$HOME/.nexus-ai-gateway.env"
+SERVICE="nexus-ai-gateway"
+
+APPLY=false
+RESTART=true
+FORCE=false
+
+usage() {
+  cat <<EOF
+sync-from-release.sh — install the latest GitHub Release binary (glibc-safe, branch-independent)
+
+Usage: $0 [--apply] [--no-restart] [--force] [-h]
+
+  (no flags)    DRY-RUN: report installed vs latest, make NO changes (default)
+  --apply       Download/build + install the latest release version
+  --no-restart  With --apply: install but do NOT restart the systemd service
+  --force       Reinstall even if the installed version already matches
+  -h, --help    Show this help
+EOF
+}
+
+for arg in "$@"; do
+  case "$arg" in
+    --apply) APPLY=true ;;
+    --no-restart) RESTART=false ;;
+    --force) FORCE=true ;;
+    -h | --help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "Unknown arg: $arg" >&2
+      usage
+      exit 2
+      ;;
+  esac
+done
+
+installed_version() {
+  if [ -x "$CARGO_BIN" ]; then
+    "$CARGO_BIN" --version 2>/dev/null | awk '{print $2}'
+  fi
+}
+
+INSTALLED="$(installed_version)"
+[ -z "$INSTALLED" ] && INSTALLED="none"
+
+if ! command -v gh >/dev/null 2>&1; then
+  echo "❌ gh CLI not found — cannot query releases" >&2
+  exit 1
+fi
+
+LATEST_TAG="$(gh release view --repo "$REPO" --json tagName -q .tagName 2>/dev/null || true)"
+if [ -z "$LATEST_TAG" ]; then
+  echo "❌ Could not determine latest release tag for $REPO" >&2
+  exit 1
+fi
+LATEST_VER="${LATEST_TAG#v}"
+
+echo "Repo:            $REPO"
+echo "Installed:       $INSTALLED  ($CARGO_BIN)"
+echo "Latest release:  $LATEST_VER ($LATEST_TAG)"
+
+if [ "$INSTALLED" = "$LATEST_VER" ] && [ "$FORCE" = false ]; then
+  echo "✅ Up to date — nothing to do."
+  exit 0
+fi
+
+if [ "$APPLY" = false ]; then
+  echo ""
+  echo "→ Update available: $INSTALLED → $LATEST_VER"
+  echo "  Re-run with --apply to install (dry-run made no changes)."
+  exit 0
+fi
+
+# ---------------------------------------------------------------------------
+# APPLY path
+# ---------------------------------------------------------------------------
+TMP="$(mktemp -d)"
+cleanup() { rm -rf "$TMP"; }
+trap cleanup EXIT
+
+STAGED="$TMP/$BINARY_NAME"
+SOURCE_DESC=""
+
+echo ""
+echo "⬇  Downloading Release asset $LATEST_TAG…"
+if gh release download "$LATEST_TAG" --repo "$REPO" -p "$BINARY_NAME" -D "$TMP" --clobber 2>/dev/null; then
+  chmod +x "$STAGED" 2>/dev/null || true
+  DL_VER="$("$STAGED" --version 2>/dev/null | awk '{print $2}')"
+  if [ "$DL_VER" = "$LATEST_VER" ]; then
+    SOURCE_DESC="CI Release asset ($LATEST_TAG)"
+    echo "✅ Release asset runs on this host and reports v$DL_VER"
+  else
+    echo "⚠  Release asset is not usable here (glibc mismatch or wrong version: '${DL_VER:-<none>}')."
+    STAGED="" # force local-build fallback
+  fi
+else
+  echo "⚠  Release asset download failed."
+  STAGED=""
+fi
+
+# Fallback: build locally against this host's glibc.
+if [ -z "$STAGED" ]; then
+  echo ""
+  echo "🔨 Falling back to local build (cargo build --release)…"
+  REPO_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+  if ! (cd "$REPO_DIR" && cargo build --release); then
+    echo "❌ Local build failed — prod NOT changed." >&2
+    exit 1
+  fi
+  BUILT="$REPO_DIR/target/release/$BINARY_NAME"
+  BUILT_VER="$("$BUILT" --version 2>/dev/null | awk '{print $2}')"
+  if [ "$BUILT_VER" != "$LATEST_VER" ]; then
+    echo "❌ Built v${BUILT_VER:-<none>} != latest v$LATEST_VER — your checkout is behind." >&2
+    echo "   Run 'git checkout main && git pull' first. prod NOT changed." >&2
+    exit 1
+  fi
+  STAGED="$BUILT"
+  SOURCE_DESC="local build (host glibc $(ldd --version 2>/dev/null | awk 'NR==1{print $NF}'))"
+fi
+
+# Install to both canonical paths + md5 cross-verify (mirrors 'task sync-binary').
+mkdir -p "$(dirname "$CARGO_BIN")" "$(dirname "$LOCAL_BIN")"
+install -m 0755 "$STAGED" "$CARGO_BIN"
+install -m 0755 "$STAGED" "$LOCAL_BIN"
+SRC_MD5="$(md5sum "$STAGED" | awk '{print $1}')"
+CARGO_MD5="$(md5sum "$CARGO_BIN" | awk '{print $1}')"
+LOCAL_MD5="$(md5sum "$LOCAL_BIN" | awk '{print $1}')"
+if [ "$SRC_MD5" != "$CARGO_MD5" ] || [ "$SRC_MD5" != "$LOCAL_MD5" ]; then
+  echo "❌ md5 mismatch after install — prod binary may be corrupt. NOT restarting." >&2
+  exit 1
+fi
+echo "✅ Installed v$LATEST_VER from $SOURCE_DESC (md5 ${SRC_MD5:0:8})"
+
+if [ "$RESTART" = false ]; then
+  echo "↩  --no-restart: run 'systemctl --user restart $SERVICE' when ready."
+  exit 0
+fi
+
+echo ""
+echo "🔄 Restarting $SERVICE…"
+if ! systemctl --user restart "$SERVICE"; then
+  echo "❌ Service restart failed." >&2
+  exit 1
+fi
+sleep 3
+PORT="$(grep -E '^PORT=' "$ENV_FILE" 2>/dev/null | cut -d= -f2 | tr -d '[:space:]')"
+PORT="${PORT:-8315}"
+if [ "$(curl -s --max-time 5 "http://localhost:${PORT}/health" 2>/dev/null)" = "OK" ]; then
+  echo "✅ Deploy complete — v$LATEST_VER healthy on :$PORT"
+else
+  echo "⚠  Service restarted but /health did not return OK on :$PORT — check 'task service-logs'." >&2
+  exit 1
+fi

--- a/src/proxy/classify.rs
+++ b/src/proxy/classify.rs
@@ -180,13 +180,25 @@ pub(crate) fn classify_error(upstream: &UpstreamError) -> ErrorClass {
             };
         }
 
-        // Within retryable status, L1 FIXABLE patterns CAN refine
-        // (e.g., a 502 wrapping a token overflow should be Fixable)
-        for pattern in FIXABLE_PATTERNS {
-            if lower.contains(pattern) {
-                return ErrorClass::Fixable {
-                    reason: "fixable pattern in retryable status (L1+guard)",
-                };
+        // Within retryable status, L1 FIXABLE patterns CAN refine a TRUE server error
+        // (e.g., a 500/504 wrapping a token overflow should be Fixable).
+        //
+        // EXCEPT rate-limit / overload statuses (429, 502, 503, 529): a rate limit is
+        // NEVER fixed by clamping max_tokens, and the Fixable path retries WITHOUT
+        // backoff — 3 instant retries all hit the limit and the stream dies. NIM's 429
+        // body incidentally contains "max_tokens"/"token limit", which used to match
+        // FIXABLE_PATTERNS and mis-route the rate limit into the clamp path. These must
+        // back off (Retryable), matching Anthropic's backend: CC retries 429/5xx with
+        // Retry-After (`x-should-retry` is already set in error.rs). (Fix: streams dying
+        // on every NIM rate limit — "exhausted 3 retries — giving up" in <1s.)
+        let is_rate_or_overload = matches!(status, 429 | 502 | 503 | 529);
+        if !is_rate_or_overload {
+            for pattern in FIXABLE_PATTERNS {
+                if lower.contains(pattern) {
+                    return ErrorClass::Fixable {
+                        reason: "fixable pattern in retryable status (L1+guard)",
+                    };
+                }
             }
         }
 

--- a/src/proxy/classify_test.rs
+++ b/src/proxy/classify_test.rs
@@ -112,6 +112,36 @@ fn m7_429_unauthorized_in_body_is_retryable_not_fatal() {
     );
 }
 
+#[test]
+fn rate_limit_with_token_words_in_body_is_retryable_not_fixable() {
+    // Regression (stream-death bug): NIM's 429/529 body incidentally mentions
+    // "max_tokens"/"token limit", which used to match FIXABLE_PATTERNS and route the rate
+    // limit into the no-backoff clamp path — 3 instant retries that all hit the limit and
+    // the stream dies ("exhausted 3 retries — giving up" in <1s). A rate limit / overload
+    // must back off (Retryable), matching Anthropic's backend.
+    for status in [429u16, 502, 503, 529] {
+        let err = make_error(status, "rate limit exceeded; reduce max_tokens or token limit");
+        let class = classify_error(&err);
+        assert!(
+            matches!(class, ErrorClass::Retryable { .. }),
+            "status {status} + token words in body must be Retryable (backoff), got {:?}",
+            class
+        );
+    }
+}
+
+#[test]
+fn genuine_500_token_overflow_stays_fixable() {
+    // The refine is preserved for TRUE server errors: a token overflow wrapped in a 500
+    // (not a rate limit) is still Fixable (clamp).
+    let err = make_error(500, "internal error: maximum context length exceeded");
+    assert!(
+        matches!(classify_error(&err), ErrorClass::Fixable { .. }),
+        "500 + token-overflow body should remain Fixable, got {:?}",
+        classify_error(&err)
+    );
+}
+
 // ═══════════════════════════════════════════════════════════════
 // M8: L0 multi-provider error_type matching
 // ═══════════════════════════════════════════════════════════════
@@ -349,12 +379,23 @@ fn l2_429_reduced_retries() {
 
 #[test]
 fn fixable_within_retryable_status() {
-    // A 502 wrapping a token overflow should be Fixable
+    // Updated: the FIXABLE refine within a retryable status applies only to TRUE server
+    // errors (500/504), NOT to rate-limit/overload statuses (429/502/503/529). A 502 is
+    // commonly NIM wrapping a 429 — clamping max_tokens does not fix a rate limit and the
+    // Fixable path skips the backoff, killing the stream. So 502 + a token-word body must
+    // back off (Retryable). Genuine token overflows arrive as 400 (handled elsewhere).
     let err = make_error(502, "maximum context length exceeded");
     let class = classify_error(&err);
     assert!(
-        matches!(class, ErrorClass::Fixable { .. }),
-        "502 + fixable pattern should be Fixable, got {:?}",
+        matches!(class, ErrorClass::Retryable { .. }),
+        "502 + fixable pattern must be Retryable (rate-limit/overload backoff), got {:?}",
         class
+    );
+
+    // The refine is still active for a true server error (500).
+    let err500 = make_error(500, "maximum context length exceeded");
+    assert!(
+        matches!(classify_error(&err500), ErrorClass::Fixable { .. }),
+        "500 + fixable pattern should remain Fixable"
     );
 }

--- a/src/proxy/discovery.rs
+++ b/src/proxy/discovery.rs
@@ -41,11 +41,24 @@ pub type ModelCache = Arc<AsyncRwLock<HashMap<String, ModelCapabilities>>>;
 /// was both wrong and harmful. Pin genuinely smaller models via
 /// `MODEL_LIMIT_OVERRIDES` instead of lowering this fallback.
 pub(crate) fn default_context_limit() -> u32 {
-    std::env::var("PROBE_FALLBACK_CONTEXT_LIMIT")
-        .ok()
-        .and_then(|v| v.parse().ok())
-        .filter(|&v| v > 0)
-        .unwrap_or(200_000)
+    const FALLBACK: u32 = 200_000;
+    match std::env::var("PROBE_FALLBACK_CONTEXT_LIMIT") {
+        // Unset is the normal case — silently use the default.
+        Err(_) => FALLBACK,
+        Ok(raw) => match raw.parse::<u32>() {
+            Ok(v) if v > 0 => v,
+            // Present but invalid (non-numeric or <= 0): warn so a misconfigured env
+            // var is debuggable instead of silently masked, then use the default.
+            _ => {
+                tracing::warn!(
+                    "[WARN] Invalid PROBE_FALLBACK_CONTEXT_LIMIT='{}' (expected positive integer) — using default {}",
+                    raw,
+                    FALLBACK
+                );
+                FALLBACK
+            }
+        },
+    }
 }
 
 // FASE 3.6: Environment-variable configurable probe settings

--- a/src/proxy/discovery.rs
+++ b/src/proxy/discovery.rs
@@ -28,7 +28,25 @@ pub struct ModelCapabilities {
 /// Cache for model capabilities, populated by probing NIM
 pub type ModelCache = Arc<AsyncRwLock<HashMap<String, ModelCapabilities>>>;
 
-pub(crate) const DEFAULT_CONTEXT_LIMIT: u32 = 131_072;
+/// Fallback context window used when runtime probing of a model fails.
+///
+/// Configurable via `PROBE_FALLBACK_CONTEXT_LIMIT` (default 200_000). The default
+/// MUST be >= CC's context window (`CC_CONTEXT_WINDOW`, default 200_000) so that
+/// `scale_token_usage` takes Branch 2 (report REAL tokens) instead of inflating
+/// them. The previous fixed default of 131_072 was SMALLER than CC's effective
+/// window (~180_000), so a probe failure forced a ~1.37x token inflation
+/// (180_000 / 131_072) that made CC's context appear to fill within seconds and
+/// fired a premature synthetic "context window full" error. Modern NIM models
+/// (qwen, glm, deepseek, kimi) are >= 256K, so assuming 128K on a probe failure
+/// was both wrong and harmful. Pin genuinely smaller models via
+/// `MODEL_LIMIT_OVERRIDES` instead of lowering this fallback.
+pub(crate) fn default_context_limit() -> u32 {
+    std::env::var("PROBE_FALLBACK_CONTEXT_LIMIT")
+        .ok()
+        .and_then(|v| v.parse().ok())
+        .filter(|&v| v > 0)
+        .unwrap_or(200_000)
+}
 
 // FASE 3.6: Environment-variable configurable probe settings
 fn cache_ttl_secs() -> u64 {
@@ -147,10 +165,50 @@ pub async fn get_context_limit(
         return limit;
     }
 
+    let fallback = default_context_limit();
     tracing::warn!(
-        "[WARN] Could not probe model '{}', using default {}",
+        "[WARN] Could not probe model '{}', using fallback {} (tune via PROBE_FALLBACK_CONTEXT_LIMIT)",
         model,
-        DEFAULT_CONTEXT_LIMIT
+        fallback
     );
-    DEFAULT_CONTEXT_LIMIT
+    fallback
+}
+
+#[cfg(test)]
+mod fallback_tests {
+    use super::default_context_limit;
+
+    /// Save/restore the single (uniquely-named) env var this module touches so the
+    /// test is order-independent. Only this test reads/writes this key, so there is
+    /// no cross-test race on the process-wide environment.
+    fn with_env<T>(value: Option<&str>, f: impl FnOnce() -> T) -> T {
+        let key = "PROBE_FALLBACK_CONTEXT_LIMIT";
+        let prev = std::env::var(key).ok();
+        match value {
+            Some(v) => std::env::set_var(key, v),
+            None => std::env::remove_var(key),
+        }
+        let out = f();
+        match prev {
+            Some(p) => std::env::set_var(key, p),
+            None => std::env::remove_var(key),
+        }
+        out
+    }
+
+    #[test]
+    fn probe_fallback_default_and_overrides() {
+        // Default 200_000 and >= CC's effective window (~180K) so a probe failure
+        // never pushes scale_token_usage into its inflating Branch 1 — the root of
+        // the "context fills in 2 seconds" bug. Modern NIM models are >= 256K, so
+        // the old 128K default was both wrong and harmful.
+        let d = with_env(None, default_context_limit);
+        assert_eq!(d, 200_000, "default fallback should be 200_000");
+        assert!(d >= 180_000, "fallback must be >= CC effective window (no inflation)");
+        // Env override is honoured.
+        assert_eq!(with_env(Some("262144"), default_context_limit), 262_144);
+        // Invalid values fall back to the default.
+        assert_eq!(with_env(Some("0"), default_context_limit), 200_000);
+        assert_eq!(with_env(Some("garbage"), default_context_limit), 200_000);
+    }
 }


### PR DESCRIPTION
## Summary

Three interconnected bugs that broke the goal of NEXUS feeling like the official
Anthropic/Claude.ai backend. Root causes were triangulated across the NEXUS codebase, the
prod log, live Claude Code transcripts, and the **Claude Code 2.1.175 binary** (reverse-
engineered to learn exactly what behaviour CC expects from its backend).

| # | Symptom | Root cause | Fix |
|---|---------|-----------|-----|
| **1** | Stream dies: "API Error: 502 Fixable error after 3 retries"; CC unusable under load | A NIM `429/529/502` whose body mentions "max_tokens"/"token limit" matched the FIXABLE refine → classified Fixable → max_tokens clamp + **no backoff** → 3 instant retries (~600ms) → give up | Exclude rate-limit/overload statuses (429/502/503/529) from the FIXABLE refine → Retryable with backoff |
| **3** | "Context window full" in ~2 seconds; premature `/compact` | Probe failure → fallback **128K** < CC window (~180K) → `scale_token_usage` Branch 1 inflates usage **×1.37**; large MCP-tool baseline crosses the 90% threshold almost immediately | Probe-fail fallback **128K → 200K** (≥ CC window) → Branch 2 reports **real** tokens → CC manages compaction client-side, exactly as against the real backend |
| **2** | Prod binary 0.21.0 vs Release 0.21.1 (persistent lag) | (a) CI builds on `ubuntu-latest` (glibc 2.39) → asset fails "GLIBC_2.39 not found" on prod (glibc 2.35) → un-runnable, deploy can only rebuild; (b) post-merge hook misses the `[skip ci]` bump when fetched off-main | Pin release job to `ubuntu-22.04` (glibc 2.35, portable) + `scripts/sync-from-release.sh` (branch-independent, idempotent, dry-run default, glibc-verified, rebuild fallback) |

## Why these match Anthropic's behaviour

Extracted from the CC 2.1.175 binary:
- **Retries:** CC honours `x-should-retry` then retries `408/409/429/5xx` with `Retry-After`.
  NEXUS already sets `x-should-retry: true` + `retry-after` for these — Fix #1 makes the
  classifier stop clamping them so the backoff actually happens and CC retries cleanly.
- **Context:** CC tracks `context_left` **client-side** from the `usage` field and auto-
  compacts at its own `thresholdTokens` (windows 180000/200000). The real backend never
  emits "context window full". Fix #3 makes NEXUS report **accurate** usage so CC's own
  compaction triggers correctly instead of being forced early by inflated numbers.

## Commits

- `bf0f8ae` fix: rate-limit/overload statuses always back off, never clamp (#1)
- `b7acf91` fix: probe-fail fallback 200K — stop token inflation (#3)
- `24fc2c5` fix(ci): release on ubuntu-22.04 + glibc-safe sync-from-release script (#2)

## Test plan

- [x] `cargo fmt --check` clean
- [x] Full suite **347 passed / 0 failed** (new: `rate_limit_with_token_words_in_body_is_retryable_not_fixable`, `genuine_500_token_overflow_stays_fixable`, updated `fixable_within_retryable_status`, `probe_fallback_default_and_overrides`)
- [x] `cargo clippy -- -D warnings` (CI gate) exit 0
- [x] `version_sync` 3/3
- [x] `shellcheck scripts/sync-from-release.sh` clean; dry-run reports `0.21.0 → 0.21.1` and makes **no** changes (prod untouched, `:8315` active)
- [x] Fix #3 validated live on **:8316** (isolated test env, real NIM upstream): probe-fail now logs `using fallback 200000`; CC window 200K → scaler takes Branch 2 (real tokens); no premature "Context nearly full"
- [ ] CodeRabbit review → address all findings → **merge only on explicit owner confirmation**

## Notes / follow-ups (out of scope here)

- The published Release binary was previously **un-runnable on glibc < 2.39** — Fix #2 pins
  the runner so future releases are portable; the current v0.21.1 asset stays glibc-2.39, so
  the sync script's rebuild fallback covers the immediate lag.
- Pre-existing: `cargo clippy --all-targets` flags 4 test-only lints (`error_test.rs:21`,
  `classify_test.rs:358`, `transform_test.rs:167`, `watcher_test.rs:183`) — not introduced
  here; CI uses the non-`--all-targets` invocation so they don't gate. Optional cleanup later.
- Pre-existing: `Taskfile.yaml` fails `task --list` under the installed go-task (`invalid keys
  in command` at the `version` target) — independent of this PR.
- The :8316 upstream returned empty (connection hangs ~60s) with the test credential — a
  test-env credential/connectivity matter, orthogonal to these three fixes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a binary sync script to reconcile locally installed gateway with the latest release.
  * Made context limit configurable via environment variable for better operational flexibility.

* **Bug Fixes**
  * Improved error classification to correctly identify rate-limit and overload responses instead of misclassifying them as fixable errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->