### PR TITLE
security: bind hardening (127.0.0.1 default) + IP allowlist + systemd/firewall (#78)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- `BIND_ADDR` env var + `--bind` CLI flag — configurable listener bind address (default `127.0.0.1`, loopback-only) (#108, #78)
+- `ALLOWED_IPS` env var — optional per-request IP allowlist middleware (defense-in-depth); loopback always allowed (#108)
+- `scripts/harden-firewall.sh` — idempotent explicit UFW rule for the proxy port (`--dry-run`, `--allow-lan <cidr>`) (#108)
+- systemd `RestrictAddressFamilies` network hardening in `scripts/nexus-ai-gateway.service` (#108)
 
 ### Changed
+- **Security (bind hardening):** the listener now defaults to `127.0.0.1` (loopback-only) instead of the previously hardcoded `0.0.0.0`. The proxy is no longer reachable from the LAN unless `BIND_ADDR=0.0.0.0` is set explicitly (opt-in), which also logs a warning. Mitigates unauthenticated LAN exposure (#78). The legacy `HOST` variable is deprecated and ignored (warns when set without `BIND_ADDR`).
 
 ### Fixed
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -159,6 +159,8 @@ These behaviors are intentional and should not be changed:
 | `NEXUS_UPSTREAM_TYPE` | `nim` | Upstream type: `anthropic`, `nim`, `openai`, `openrouter` |
 | `UPSTREAM_<NAME>_TYPE` | (falls back to `NEXUS_UPSTREAM_TYPE`) | Per-upstream type override. `<NAME>` matches the upstream name (e.g., `UPSTREAM_BIGMODEL_TYPE=anthropic`). Overrides global `NEXUS_UPSTREAM_TYPE` for that upstream |
 | `PORT` | `8315` | Server port |
+| `BIND_ADDR` | `127.0.0.1` | Listener bind address (Issue #78). `0.0.0.0` exposes on all interfaces (opt-in; warns when non-loopback). Legacy `HOST` is deprecated/ignored. Overridable via `--bind` |
+| `ALLOWED_IPS` | (none) | Optional comma-separated CIDR/IP allowlist (defense-in-depth). Empty = allow all; loopback always allowed |
 | `DEBUG` | `false` | Enable debug logging |
 | `VERBOSE` | `false` | Full request/response logging |
 | `CC_CONTEXT_WINDOW` | `200000` | Context window size for auto-compact calibration |

--- a/README.md
+++ b/README.md
@@ -182,6 +182,8 @@ flowchart TB
 | Variable | Default | Description |
 |----------|---------|-------------|
 | `PORT` | `8315` | HTTP server port |
+| `BIND_ADDR` | `127.0.0.1` | Listener bind address (loopback-only by default). Set `0.0.0.0` to expose on all interfaces (opt-in). Also `--bind`. Legacy `HOST` is deprecated/ignored |
+| `ALLOWED_IPS` | — | Optional comma-separated CIDR/IP allowlist (defense-in-depth). Empty = allow all; loopback always allowed |
 | `CORS_ALLOWED_ORIGINS` | `http://localhost:8315` | Comma-separated allowed origins |
 
 #### Model Routing

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -13,7 +13,39 @@ Do NOT file public issues for security vulnerabilities.
 
 ## Security Features
 - API keys stored in .env files (never hardcoded)
+- **Loopback-only bind by default** (`BIND_ADDR=127.0.0.1`) — not reachable from the network unless opted in
+- **Optional IP allowlist** (`ALLOWED_IPS`) — per-request access control, defense-in-depth
 - SSRF protection in WebFetch (RFC1918 IP blocking)
 - CORS defaults to localhost only
 - Circuit breaker for cascade failure prevention
 - .env file permissions set to 600 on Unix
+- systemd `RestrictAddressFamilies` network hardening
+
+## Network Exposure & Access Control (Issue #78)
+
+By default NEXUS binds to **`127.0.0.1`** and is reachable only from the local
+machine — exactly what the Claude Code client needs (`ANTHROPIC_BASE_URL=http://localhost:<port>`).
+Exposing the proxy to other devices is an explicit, layered opt-in:
+
+| Layer | Variable / artifact | Default | Purpose |
+|-------|---------------------|---------|---------|
+| Bind address | `BIND_ADDR` (or `--bind`) | `127.0.0.1` | Which interfaces the listener accepts. `0.0.0.0` = all interfaces (opt-in). Emits a warning when non-loopback. |
+| IP allowlist | `ALLOWED_IPS` | empty (allow all) | Comma-separated CIDRs/IPs permitted to reach the proxy. Loopback is **always** allowed. |
+| Host firewall | `scripts/harden-firewall.sh` | not applied | Explicit UFW rule for the port (`--dry-run`, `--allow-lan <cidr>`). |
+| systemd | `scripts/nexus-ai-gateway.service` | `RestrictAddressFamilies` | Restricts socket families. (IP egress filtering intentionally NOT enabled — it would break outbound calls to the upstream.) |
+
+**Legacy `HOST` variable:** deprecated and ignored — it never controlled the
+listener. Use `BIND_ADDR` instead. A warning is logged if `HOST` is set without `BIND_ADDR`.
+
+**To expose on a LAN safely:**
+```bash
+# 1) Bind to all interfaces (opt-in)
+BIND_ADDR=0.0.0.0
+# 2) Restrict who may connect
+ALLOWED_IPS=192.168.1.0/24
+# 3) Make the firewall rule explicit
+./scripts/harden-firewall.sh --allow-lan 192.168.1.0/24
+```
+
+> Changing `BIND_ADDR` or `ALLOWED_IPS` requires a restart (the socket and middleware
+> are configured once at startup; they are not hot-reloaded).

--- a/scripts/harden-firewall.sh
+++ b/scripts/harden-firewall.sh
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+# ============================================================
+# harden-firewall.sh — Explicit UFW rule for the NEXUS port (Issue #78, Solution D).
+#
+# By default NEXUS binds to 127.0.0.1 (Solution A), so the port is already
+# unreachable from the network. This script makes that protection EXPLICIT at the
+# host firewall, so it survives even if someone later sets BIND_ADDR=0.0.0.0 or
+# disables the implicit "default deny incoming" policy.
+#
+# Usage:
+#   ./scripts/harden-firewall.sh                         # deny <PORT>/tcp (default 8315)
+#   PORT=8316 ./scripts/harden-firewall.sh               # custom port via env
+#   ./scripts/harden-firewall.sh --port 8316             # custom port via flag
+#   ./scripts/harden-firewall.sh --allow-lan 192.168.1.0/24   # allow ONLY that CIDR
+#   ./scripts/harden-firewall.sh --dry-run               # print commands, change nothing
+#
+# Idempotent: UFW skips rules that already exist. Requires `ufw` + sudo.
+# ============================================================
+set -euo pipefail
+
+PORT="${PORT:-8315}"
+DRY_RUN=0
+ALLOW_LAN=""
+
+print_help() {
+    sed -n '2,18p' "$0" | sed 's/^# \{0,1\}//'
+}
+
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --dry-run) DRY_RUN=1; shift ;;
+        --allow-lan)
+            ALLOW_LAN="${2:-}"
+            [ -n "$ALLOW_LAN" ] || { echo "❌ --allow-lan requires a CIDR (e.g. 192.168.1.0/24)" >&2; exit 2; }
+            shift 2 ;;
+        --port)
+            PORT="${2:-}"
+            shift 2 ;;
+        -h|--help) print_help; exit 0 ;;
+        *) echo "❌ Unknown argument: $1" >&2; exit 2 ;;
+    esac
+done
+
+# Validate port range.
+if ! [[ "$PORT" =~ ^[0-9]+$ ]] || [ "$PORT" -lt 1 ] || [ "$PORT" -gt 65535 ]; then
+    echo "❌ Invalid PORT: '$PORT' (expected 1-65535)" >&2
+    exit 2
+fi
+
+if ! command -v ufw >/dev/null 2>&1; then
+    echo "❌ 'ufw' not found. Install it (sudo apt install ufw) or configure your firewall manually." >&2
+    exit 1
+fi
+
+# Build the rule as an array (safe quoting).
+if [ -n "$ALLOW_LAN" ]; then
+    RULE=(ufw allow from "$ALLOW_LAN" to any port "$PORT" proto tcp)
+    echo "🔓 Allow ONLY $ALLOW_LAN to reach port $PORT/tcp; all other sources fall through to 'default deny incoming'."
+else
+    RULE=(ufw deny "$PORT"/tcp)
+    echo "🔒 Explicitly DENY port $PORT/tcp from all sources (matches the secure default BIND_ADDR=127.0.0.1)."
+fi
+
+if [ "$DRY_RUN" -eq 1 ]; then
+    echo "🧪 DRY-RUN — no changes made. Would execute:"
+    if [ -n "$ALLOW_LAN" ]; then
+        echo "   sudo ufw delete deny $PORT/tcp   # remove any conflicting blanket-deny first"
+    fi
+    echo "   sudo ${RULE[*]}"
+    exit 0
+fi
+
+# In allow-lan mode, drop a prior blanket deny so the allow rule can take effect
+# (UFW evaluates rules in order; a leading deny would shadow the allow).
+if [ -n "$ALLOW_LAN" ]; then
+    sudo ufw delete deny "$PORT"/tcp 2>/dev/null || true
+fi
+
+echo "▶  sudo ${RULE[*]}"
+sudo "${RULE[@]}"
+
+echo "✅ Done. Current UFW rules mentioning port $PORT:"
+sudo ufw status | grep -E "(^| )$PORT(/| |\b)" || echo "   (none shown — run 'sudo ufw status numbered' to inspect)"

--- a/scripts/nexus-ai-gateway.service
+++ b/scripts/nexus-ai-gateway.service
@@ -38,5 +38,21 @@ ProtectSystem=strict
 ProtectHome=read-only
 ReadWritePaths=/tmp %h/.local/share/nexus-ai-gateway
 
+# Network hardening (Issue #78)
+# Restrict socket families to IPv4/IPv6/Unix — blocks raw/packet/netlink sockets
+# while preserving normal TCP traffic and local DNS resolution (nss/resolved).
+RestrictAddressFamilies=AF_INET AF_INET6 AF_UNIX
+#
+# NOTE: We deliberately DO NOT set `IPAddressDeny=any`. systemd IP address filtering
+# is bidirectional — it would also block this proxy's OUTBOUND connections to the
+# upstream API (e.g. NVIDIA NIM) and the telemetry beacon, breaking all traffic.
+# Inbound exposure is governed instead by:
+#   - BIND_ADDR (default 127.0.0.1, loopback-only)         — application layer
+#   - scripts/harden-firewall.sh (explicit UFW rule)        — host firewall
+#   - ALLOWED_IPS (optional per-request allowlist)          — middleware
+# If you pin a STATIC upstream IP you may additionally enable strict egress, e.g.:
+#   IPAddressDeny=any
+#   IPAddressAllow=localhost <upstream-cidr>
+
 [Install]
 WantedBy=default.target

--- a/src/access_control.rs
+++ b/src/access_control.rs
@@ -1,0 +1,207 @@
+//! IP allowlist access control (Issue #78, Solution B).
+//!
+//! Defense-in-depth layer that restricts which client IPs may reach the proxy,
+//! independent of the bind address. This complements the secure-by-default bind
+//! (Solution A): even when an operator opts into `BIND_ADDR=0.0.0.0` for LAN
+//! access, they can scope *who* may connect with `ALLOWED_IPS`.
+//!
+//! Opt-in: when `ALLOWED_IPS` is empty/unset the middleware is not mounted and
+//! every client is allowed (the bind address governs exposure). When set, only
+//! listed networks — plus loopback, always — may reach the proxy; everyone else
+//! receives `403 Forbidden`.
+
+use axum::{
+    extract::{ConnectInfo, Request, State},
+    http::StatusCode,
+    middleware::Next,
+    response::Response,
+};
+use ipnet::IpNet;
+use std::net::{IpAddr, SocketAddr};
+
+/// Parsed allowlist of permitted client networks (Issue #78).
+#[derive(Debug, Clone, Default)]
+pub struct IpAllowlist {
+    nets: Vec<IpNet>,
+}
+
+impl IpAllowlist {
+    /// Parse a comma-separated list of CIDRs and/or bare IPs.
+    ///
+    /// - `192.168.1.0/24` -> network match.
+    /// - `203.0.113.7` (bare IP) -> host route (`/32` for IPv4, `/128` for IPv6).
+    /// - Invalid entries are skipped with a warning (parse, don't validate).
+    pub fn parse(raw: &str) -> Self {
+        let mut nets = Vec::new();
+        for entry in raw.split(',') {
+            let entry = entry.trim();
+            if entry.is_empty() {
+                continue;
+            }
+            if let Ok(net) = entry.parse::<IpNet>() {
+                nets.push(net);
+            } else if let Ok(ip) = entry.parse::<IpAddr>() {
+                // Bare IP -> host network with full prefix length.
+                nets.push(IpNet::from(ip));
+            } else {
+                tracing::warn!("ALLOWED_IPS: ignoring invalid entry '{}'", entry);
+            }
+        }
+        Self { nets }
+    }
+
+    /// True when no networks are configured (no restriction).
+    pub fn is_empty(&self) -> bool {
+        self.nets.is_empty()
+    }
+
+    /// Number of configured networks (for startup logging).
+    pub fn len(&self) -> usize {
+        self.nets.len()
+    }
+
+    /// Whether a client IP is permitted.
+    ///
+    /// Loopback (`127.0.0.0/8`, `::1`) is **always** allowed regardless of the
+    /// configured list. This guarantees local health checks, Prometheus scrapes,
+    /// and the Claude Code client (which connects via `localhost`) keep working
+    /// even if the operator forgets to add loopback to `ALLOWED_IPS`.
+    pub fn allows(&self, ip: IpAddr) -> bool {
+        if ip.is_loopback() {
+            return true;
+        }
+        self.nets.iter().any(|net| net.contains(&ip))
+    }
+}
+
+/// Axum middleware enforcing the [`IpAllowlist`] against the peer socket address.
+///
+/// The client IP is taken from `ConnectInfo<SocketAddr>`, which is populated by
+/// `into_make_service_with_connect_info::<SocketAddr>()` in `main`. Requests from
+/// non-allowed IPs are rejected with `403 Forbidden` before reaching any handler.
+pub async fn ip_allowlist_middleware(
+    State(allowlist): State<IpAllowlist>,
+    ConnectInfo(addr): ConnectInfo<SocketAddr>,
+    request: Request,
+    next: Next,
+) -> Result<Response, StatusCode> {
+    if allowlist.allows(addr.ip()) {
+        Ok(next.run(request).await)
+    } else {
+        tracing::warn!(
+            "[access_control] Rejected {} — not in ALLOWED_IPS (loopback always permitted)",
+            addr.ip()
+        );
+        Err(StatusCode::FORBIDDEN)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn ip(s: &str) -> IpAddr {
+        s.parse().expect("test IP must parse")
+    }
+
+    #[test]
+    fn empty_input_yields_empty_allowlist() {
+        assert!(IpAllowlist::parse("").is_empty());
+        assert!(IpAllowlist::parse("   ").is_empty());
+        assert!(IpAllowlist::parse(" , , ").is_empty());
+    }
+
+    #[test]
+    fn loopback_always_allowed_even_when_not_listed() {
+        let al = IpAllowlist::parse("192.168.1.0/24");
+        assert!(al.allows(ip("127.0.0.1")));
+        assert!(al.allows(ip("127.0.0.5")));
+        assert!(al.allows(ip("::1")));
+    }
+
+    #[test]
+    fn loopback_allowed_on_empty_list_but_others_denied() {
+        // allows() is the predicate; the middleware is only mounted when non-empty.
+        let al = IpAllowlist::parse("");
+        assert!(al.allows(ip("127.0.0.1")));
+        assert!(!al.allows(ip("8.8.8.8")));
+    }
+
+    #[test]
+    fn cidr_membership() {
+        let al = IpAllowlist::parse("192.168.1.0/24");
+        assert!(al.allows(ip("192.168.1.1")));
+        assert!(al.allows(ip("192.168.1.254")));
+        assert!(!al.allows(ip("192.168.2.1")));
+        assert!(!al.allows(ip("8.8.8.8")));
+    }
+
+    #[test]
+    fn bare_ipv4_becomes_host_route() {
+        let al = IpAllowlist::parse("203.0.113.7");
+        assert!(al.allows(ip("203.0.113.7")));
+        assert!(!al.allows(ip("203.0.113.8")));
+    }
+
+    #[test]
+    fn multiple_entries_with_ipv6_and_whitespace() {
+        let al = IpAllowlist::parse(" 10.0.0.0/8 , 2001:db8::/32 ,192.168.1.1 ");
+        assert!(al.allows(ip("10.255.1.2")));
+        assert!(al.allows(ip("2001:db8::dead:beef")));
+        assert!(al.allows(ip("192.168.1.1")));
+        assert!(!al.allows(ip("172.16.0.1")));
+        assert!(!al.allows(ip("2001:dead::1")));
+        assert_eq!(al.len(), 3);
+    }
+
+    #[test]
+    fn invalid_entries_are_skipped_not_fatal() {
+        let al = IpAllowlist::parse("garbage, 192.168.1.0/24, 999.999.999.999, also-bad");
+        assert_eq!(al.len(), 1);
+        assert!(al.allows(ip("192.168.1.5")));
+        assert!(!al.allows(ip("1.2.3.4")));
+    }
+}
+
+#[cfg(test)]
+mod http_tests {
+    //! End-to-end middleware tests: drive a real router through the allowlist
+    //! layer with a synthetic `ConnectInfo`, asserting 200 vs 403 without a socket.
+    use super::*;
+    use axum::{body::Body, http::Request as HttpRequest, routing::get, Router};
+    use tower::ServiceExt; // ServiceExt::oneshot
+
+    async fn ok_handler() -> &'static str {
+        "ok"
+    }
+
+    fn test_app(allowed: &str) -> Router {
+        let allowlist = IpAllowlist::parse(allowed);
+        Router::new()
+            .route("/", get(ok_handler))
+            .layer(axum::middleware::from_fn_with_state(allowlist, ip_allowlist_middleware))
+    }
+
+    async fn status_from(app: Router, client_ip: &str) -> StatusCode {
+        let addr: SocketAddr = format!("{client_ip}:12345").parse().expect("valid socket addr");
+        let mut req = HttpRequest::builder().uri("/").body(Body::empty()).unwrap();
+        // Replicates what into_make_service_with_connect_info inserts at runtime.
+        req.extensions_mut().insert(ConnectInfo(addr));
+        app.oneshot(req).await.expect("router responds").status()
+    }
+
+    #[tokio::test]
+    async fn allowed_ip_passes() {
+        assert_eq!(status_from(test_app("192.168.1.0/24"), "192.168.1.50").await, StatusCode::OK);
+    }
+
+    #[tokio::test]
+    async fn disallowed_ip_is_forbidden() {
+        assert_eq!(status_from(test_app("192.168.1.0/24"), "8.8.8.8").await, StatusCode::FORBIDDEN);
+    }
+
+    #[tokio::test]
+    async fn loopback_passes_even_when_not_listed() {
+        assert_eq!(status_from(test_app("192.168.1.0/24"), "127.0.0.1").await, StatusCode::OK);
+    }
+}

--- a/src/access_control.rs
+++ b/src/access_control.rs
@@ -204,4 +204,12 @@ mod http_tests {
     async fn loopback_passes_even_when_not_listed() {
         assert_eq!(status_from(test_app("192.168.1.0/24"), "127.0.0.1").await, StatusCode::OK);
     }
+
+    #[tokio::test]
+    async fn empty_allowlist_mounted_fails_closed() {
+        // CodeRabbit #109: when ALLOWED_IPS is set but parses to no valid entries, main
+        // mounts the middleware anyway (fail closed) -> only loopback may pass.
+        assert_eq!(status_from(test_app(""), "8.8.8.8").await, StatusCode::FORBIDDEN);
+        assert_eq!(status_from(test_app(""), "127.0.0.1").await, StatusCode::OK);
+    }
 }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -30,6 +30,11 @@ pub struct Cli {
     #[arg(short, long, value_name = "PORT")]
     pub port: Option<u16>,
 
+    /// Bind address to listen on (overrides BIND_ADDR env var).
+    /// Default: 127.0.0.1 (loopback-only). Use 0.0.0.0 to expose on all interfaces (opt-in).
+    #[arg(long, value_name = "ADDR")]
+    pub bind: Option<String>,
+
     /// Run as background daemon
     #[arg(long)]
     pub daemon: bool,

--- a/src/config.rs
+++ b/src/config.rs
@@ -56,6 +56,9 @@ pub struct ModelRoute {
 #[derive(Debug, Clone)]
 pub struct Config {
     pub port: u16,
+    /// Listener bind address (Issue #78). Default `127.0.0.1` (loopback-only).
+    /// Set `BIND_ADDR=0.0.0.0` (or `--bind 0.0.0.0`) to expose on all interfaces — opt-in.
+    pub bind_addr: String,
     pub base_url: String,
     pub api_key: Option<String>,
     pub reasoning_model: Option<String>,
@@ -153,6 +156,41 @@ impl Config {
         map.get(key).cloned()
     }
 
+    /// Validate and normalize a bind address (Issue #78).
+    /// Parses the value as an `IpAddr`; on failure logs a warning and falls back
+    /// to the safe loopback default `127.0.0.1` (parse, don't validate).
+    pub(crate) fn normalize_bind_addr(raw: &str) -> String {
+        let trimmed = raw.trim();
+        match trimmed.parse::<std::net::IpAddr>() {
+            Ok(_) => trimmed.to_string(),
+            Err(_) => {
+                tracing::warn!(
+                    "Invalid BIND_ADDR='{}' — not a valid IP address. Falling back to 127.0.0.1 (loopback-only).",
+                    trimmed
+                );
+                "127.0.0.1".to_string()
+            }
+        }
+    }
+
+    /// Resolve the listener bind address (Issue #78).
+    /// Precedence: `BIND_ADDR` > safe default `127.0.0.1`.
+    /// The legacy `HOST` variable is deprecated and intentionally ignored; if it is
+    /// present without `BIND_ADDR`, warn the operator (it never controlled the bind).
+    fn resolve_bind_addr(bind_addr_raw: Option<String>, host_raw: Option<String>) -> String {
+        if bind_addr_raw.is_none() && host_raw.is_some() {
+            tracing::warn!(
+                "HOST is deprecated and ignored — it never controlled the listener. \
+                 Use BIND_ADDR instead (defaulting to 127.0.0.1). \
+                 Set BIND_ADDR=0.0.0.0 to expose on all interfaces."
+            );
+        }
+        match bind_addr_raw {
+            Some(raw) => Self::normalize_bind_addr(&raw),
+            None => "127.0.0.1".to_string(),
+        }
+    }
+
     /// Parse CC_MODEL_CONTEXT_WINDOWS env var into a HashMap.
     /// Format: "claude-opus-4-6:200000,claude-sonnet-4-6:200000"
     fn parse_model_context_windows(value: &str) -> HashMap<String, u32> {
@@ -191,6 +229,12 @@ impl Config {
     /// Create Config from a HashMap (used for thread-safe reload)
     fn from_map(data: &HashMap<String, String>) -> Result<Self> {
         let port = Self::get_from_map(data, "PORT").and_then(|p| p.parse().ok()).unwrap_or(8315);
+
+        // Issue #78: configurable bind address, default 127.0.0.1 (loopback-only).
+        let bind_addr = Self::resolve_bind_addr(
+            Self::get_from_map(data, "BIND_ADDR"),
+            Self::get_from_map(data, "HOST"),
+        );
 
         let base_url = Self::get_from_map(data, "UPSTREAM_BASE_URL").ok_or_else(|| {
             anyhow::anyhow!(
@@ -470,6 +514,7 @@ impl Config {
 
         Ok(Config {
             port,
+            bind_addr,
             base_url,
             api_key,
             reasoning_model,
@@ -546,6 +591,9 @@ impl Config {
         }
 
         let port = env::var("PORT").ok().and_then(|p| p.parse().ok()).unwrap_or(8315);
+
+        // Issue #78: configurable bind address, default 127.0.0.1 (loopback-only).
+        let bind_addr = Self::resolve_bind_addr(env::var("BIND_ADDR").ok(), env::var("HOST").ok());
 
         let base_url = env::var("UPSTREAM_BASE_URL").map_err(|_| {
             anyhow::anyhow!(
@@ -813,6 +861,7 @@ impl Config {
 
         let config = Config {
             port,
+            bind_addr,
             base_url,
             api_key,
             reasoning_model,
@@ -886,6 +935,7 @@ impl Config {
         cli_debug: bool,
         cli_verbose: bool,
         cli_port: Option<u16>,
+        cli_bind: Option<String>,
         config_path: Option<PathBuf>,
     ) -> Result<Self> {
         let env_map = Self::load_env_to_map(config_path.clone())?;
@@ -901,6 +951,12 @@ impl Config {
         }
         if let Some(port) = cli_port {
             config.port = port;
+        }
+        // Issue #78: the listener is bound once at startup and cannot be re-bound on
+        // reload; preserve the startup-resolved bind_addr so the reported config
+        // matches reality (mirrors the cli_port override behavior).
+        if let Some(bind) = cli_bind {
+            config.bind_addr = bind;
         }
         Ok(config)
     }
@@ -1075,5 +1131,81 @@ mod tests {
         let config = Config::from_map(&map).unwrap();
         // Completely unknown upstream -> falls back to global
         assert_eq!(config.get_upstream_type("nonexistent"), UpstreamType::NIM);
+    }
+
+    // =========================================================================
+    // Issue #78: bind address configuration tests
+    // =========================================================================
+
+    #[test]
+    fn test_bind_addr_defaults_to_loopback() {
+        let map = make_test_map();
+        let config = Config::from_map(&map).unwrap();
+        // Secure default: loopback-only, NOT 0.0.0.0.
+        assert_eq!(config.bind_addr, "127.0.0.1");
+    }
+
+    #[test]
+    fn test_bind_addr_override_from_env() {
+        let mut map = make_test_map();
+        map.insert("BIND_ADDR".to_string(), "0.0.0.0".to_string());
+        let config = Config::from_map(&map).unwrap();
+        // Explicit opt-in to expose on all interfaces.
+        assert_eq!(config.bind_addr, "0.0.0.0");
+    }
+
+    #[test]
+    fn test_bind_addr_ipv6_loopback_accepted() {
+        let mut map = make_test_map();
+        map.insert("BIND_ADDR".to_string(), "::1".to_string());
+        let config = Config::from_map(&map).unwrap();
+        assert_eq!(config.bind_addr, "::1");
+    }
+
+    #[test]
+    fn test_bind_addr_whitespace_trimmed() {
+        let mut map = make_test_map();
+        map.insert("BIND_ADDR".to_string(), "  192.168.1.50  ".to_string());
+        let config = Config::from_map(&map).unwrap();
+        assert_eq!(config.bind_addr, "192.168.1.50");
+    }
+
+    #[test]
+    fn test_bind_addr_invalid_falls_back_to_loopback() {
+        let mut map = make_test_map();
+        map.insert("BIND_ADDR".to_string(), "not-an-ip".to_string());
+        let config = Config::from_map(&map).unwrap();
+        // Parse, don't validate: invalid input degrades to the safe default.
+        assert_eq!(config.bind_addr, "127.0.0.1");
+    }
+
+    #[test]
+    fn test_host_alone_is_ignored_dead_config() {
+        // HOST=0.0.0.0 with NO BIND_ADDR must NOT expose the listener.
+        // HOST is legacy dead config — it never controlled the bind.
+        let mut map = make_test_map();
+        map.insert("HOST".to_string(), "0.0.0.0".to_string());
+        let config = Config::from_map(&map).unwrap();
+        assert_eq!(config.bind_addr, "127.0.0.1");
+    }
+
+    #[test]
+    fn test_bind_addr_takes_precedence_over_host() {
+        let mut map = make_test_map();
+        map.insert("HOST".to_string(), "0.0.0.0".to_string());
+        map.insert("BIND_ADDR".to_string(), "127.0.0.1".to_string());
+        let config = Config::from_map(&map).unwrap();
+        // BIND_ADDR wins; HOST is ignored entirely.
+        assert_eq!(config.bind_addr, "127.0.0.1");
+    }
+
+    #[test]
+    fn test_normalize_bind_addr_helper() {
+        assert_eq!(Config::normalize_bind_addr("0.0.0.0"), "0.0.0.0");
+        assert_eq!(Config::normalize_bind_addr("127.0.0.1"), "127.0.0.1");
+        assert_eq!(Config::normalize_bind_addr("::1"), "::1");
+        // Invalid -> safe fallback.
+        assert_eq!(Config::normalize_bind_addr("garbage"), "127.0.0.1");
+        assert_eq!(Config::normalize_bind_addr(""), "127.0.0.1");
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -173,6 +173,16 @@ impl Config {
         }
     }
 
+    /// Build the listener `SocketAddr` from a bind address string and port (Issue #78).
+    /// Uses typed `SocketAddr::new` so IPv6 addresses render correctly (e.g. `[::1]:8315`),
+    /// which plain `format!("{addr}:{port}")` cannot do (it would yield `::1:8315`).
+    pub(crate) fn resolve_socket_addr(bind_addr: &str, port: u16) -> Result<std::net::SocketAddr> {
+        let ip = bind_addr
+            .parse::<std::net::IpAddr>()
+            .map_err(|e| anyhow::anyhow!("Invalid bind address '{}': {}", bind_addr, e))?;
+        Ok(std::net::SocketAddr::new(ip, port))
+    }
+
     /// Resolve the listener bind address (Issue #78).
     /// Precedence: `BIND_ADDR` > safe default `127.0.0.1`.
     /// The legacy `HOST` variable is deprecated and intentionally ignored; if it is
@@ -1207,5 +1217,34 @@ mod tests {
         // Invalid -> safe fallback.
         assert_eq!(Config::normalize_bind_addr("garbage"), "127.0.0.1");
         assert_eq!(Config::normalize_bind_addr(""), "127.0.0.1");
+    }
+
+    // resolve_socket_addr (CodeRabbit #109): typed SocketAddr, correct IPv6 formatting.
+
+    #[test]
+    fn test_resolve_socket_addr_ipv4() {
+        let sa = Config::resolve_socket_addr("127.0.0.1", 8315).unwrap();
+        assert_eq!(sa.to_string(), "127.0.0.1:8315");
+        assert!(sa.ip().is_loopback());
+    }
+
+    #[test]
+    fn test_resolve_socket_addr_ipv6_is_bracketed() {
+        // Regression guard: plain format!("{}:{}") would yield the invalid "::1:8315".
+        let sa = Config::resolve_socket_addr("::1", 8315).unwrap();
+        assert_eq!(sa.to_string(), "[::1]:8315");
+        assert!(sa.ip().is_loopback());
+    }
+
+    #[test]
+    fn test_resolve_socket_addr_all_interfaces() {
+        let sa = Config::resolve_socket_addr("0.0.0.0", 8316).unwrap();
+        assert_eq!(sa.to_string(), "0.0.0.0:8316");
+        assert!(!sa.ip().is_loopback());
+    }
+
+    #[test]
+    fn test_resolve_socket_addr_invalid_errors() {
+        assert!(Config::resolve_socket_addr("not-an-ip", 8315).is_err());
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,4 @@
+mod access_control;
 mod circuit_breaker;
 mod cli;
 mod config;
@@ -123,6 +124,10 @@ async fn async_main(cli: Cli) -> anyhow::Result<()> {
     }
     if let Some(port) = cli.port {
         config.port = port;
+    }
+    // Issue #78: --bind overrides BIND_ADDR env (validated; invalid -> loopback).
+    if let Some(bind) = cli.bind.clone() {
+        config.bind_addr = Config::normalize_bind_addr(&bind);
     }
 
     let log_level = if config.verbose {
@@ -283,6 +288,8 @@ async fn async_main(cli: Cli) -> anyhow::Result<()> {
     let cli_debug = config.debug;
     let cli_verbose = config.verbose;
     let cli_port = Some(config.port);
+    // Issue #78: preserve the startup-resolved bind across reloads (socket is bound once).
+    let cli_bind = Some(config.bind_addr.clone());
 
     let config: SharedConfig = Arc::new(arc_swap::ArcSwap::from(Arc::new(config)));
 
@@ -328,8 +335,42 @@ async fn async_main(cli: Cli) -> anyhow::Result<()> {
         .layer(Extension(telemetry_ctx.clone()))
         .layer(cors);
 
-    let addr = format!("0.0.0.0:{}", config.clone().load().port); // v0.11.0 (CR-04)
+    // Issue #78 (Solution B): optional IP allowlist (defense-in-depth).
+    // Read directly from env, mirroring the CORS pattern above. Opt-in: when
+    // ALLOWED_IPS is empty the middleware is not mounted (the bind address governs
+    // exposure). When set, it becomes the outermost layer so non-allowed IPs are
+    // rejected before any other processing. Loopback is always permitted.
+    let allowlist =
+        access_control::IpAllowlist::parse(&std::env::var("ALLOWED_IPS").unwrap_or_default());
+    let app = if allowlist.is_empty() {
+        tracing::info!(
+            "Access control: ALLOWED_IPS not set — all client IPs allowed (bind address governs exposure)"
+        );
+        app
+    } else {
+        tracing::info!(
+            "Access control: ALLOWED_IPS active — {} network(s) permitted (loopback always allowed)",
+            allowlist.len()
+        );
+        app.layer(axum::middleware::from_fn_with_state(
+            allowlist,
+            access_control::ip_allowlist_middleware,
+        ))
+    };
+
+    // Issue #78: bind to the configured address (default 127.0.0.1, opt-in 0.0.0.0)
+    // instead of the previously hardcoded 0.0.0.0 (v0.11.0 CR-04).
+    let bind_addr = config.load().bind_addr.clone();
+    let addr = format!("{}:{}", bind_addr, config.load().port);
     let listener = tokio::net::TcpListener::bind(&addr).await?;
+
+    // Issue #78: warn loudly when reachable beyond localhost so exposure is never silent.
+    if bind_addr.parse::<std::net::IpAddr>().map(|ip| !ip.is_loopback()).unwrap_or(false) {
+        tracing::warn!(
+            "[WARN]  NEXUS is bound to {addr} — reachable beyond localhost. Configure your \
+             firewall and/or ALLOWED_IPS to restrict who can reach this proxy."
+        );
+    }
 
     tracing::info!("Listening on {}", addr);
     tracing::info!("Proxy ready to accept requests");
@@ -348,6 +389,9 @@ async fn async_main(cli: Cli) -> anyhow::Result<()> {
     let reload_in_progress = Arc::new(AtomicBool::new(false));
     let reload_flag_sighup = reload_in_progress.clone();
     let reload_flag_watcher = reload_in_progress.clone();
+    // Issue #78: per-closure clones of the startup-resolved bind for reload() calls.
+    let cli_bind_sighup = cli_bind.clone();
+    let cli_bind_watcher = cli_bind.clone();
     tokio::spawn(async move {
         let mut sighup = signal(SignalKind::hangup()).expect("Failed to register SIGHUP handler");
         loop {
@@ -367,7 +411,13 @@ async fn async_main(cli: Cli) -> anyhow::Result<()> {
                 continue;
             }
             let reload_path = reload_config.load().config_path.clone();
-            match Config::reload(cli_debug, cli_verbose, cli_port, reload_path) {
+            match Config::reload(
+                cli_debug,
+                cli_verbose,
+                cli_port,
+                cli_bind_sighup.clone(),
+                reload_path,
+            ) {
                 Ok(new_config) => {
                     let old_maps = reload_config.load().model_map.len();
                     reload_config.store(Arc::new(new_config));
@@ -503,7 +553,13 @@ async fn async_main(cli: Cli) -> anyhow::Result<()> {
 
                     tracing::info!("🔄 .env changed — auto-reloading config...");
                     let reload_path = watch_config.load().config_path.clone();
-                    match Config::reload(cli_debug, cli_verbose, cli_port, reload_path) {
+                    match Config::reload(
+                        cli_debug,
+                        cli_verbose,
+                        cli_port,
+                        cli_bind_watcher.clone(),
+                        reload_path,
+                    ) {
                         Ok(new_config) => {
                             let old_maps = watch_config.load().model_map.len();
                             watch_config.store(Arc::new(new_config));

--- a/src/main.rs
+++ b/src/main.rs
@@ -336,18 +336,24 @@ async fn async_main(cli: Cli) -> anyhow::Result<()> {
         .layer(cors);
 
     // Issue #78 (Solution B): optional IP allowlist (defense-in-depth).
-    // Read directly from env, mirroring the CORS pattern above. Opt-in: when
-    // ALLOWED_IPS is empty the middleware is not mounted (the bind address governs
-    // exposure). When set, it becomes the outermost layer so non-allowed IPs are
-    // rejected before any other processing. Loopback is always permitted.
-    let allowlist =
-        access_control::IpAllowlist::parse(&std::env::var("ALLOWED_IPS").unwrap_or_default());
-    let app = if allowlist.is_empty() {
+    // Read directly from env, mirroring the CORS pattern above. The opt-in is based on
+    // whether ALLOWED_IPS is *set*, not on whether it parses to entries: if it is set but
+    // yields no valid entries, we FAIL CLOSED (mount the middleware -> loopback-only)
+    // rather than silently allowing everyone. When unset, the bind address governs.
+    let raw_allowed_ips = std::env::var("ALLOWED_IPS").unwrap_or_default();
+    let allowlist = access_control::IpAllowlist::parse(&raw_allowed_ips);
+    let allowlist_configured = !raw_allowed_ips.trim().is_empty();
+    let app = if !allowlist_configured {
         tracing::info!(
             "Access control: ALLOWED_IPS not set — all client IPs allowed (bind address governs exposure)"
         );
         app
     } else {
+        if allowlist.is_empty() {
+            tracing::warn!(
+                "Access control: ALLOWED_IPS is set but no valid CIDR/IP entries parsed — enforcing loopback-only until fixed"
+            );
+        }
         tracing::info!(
             "Access control: ALLOWED_IPS active — {} network(s) permitted (loopback always allowed)",
             allowlist.len()
@@ -359,13 +365,16 @@ async fn async_main(cli: Cli) -> anyhow::Result<()> {
     };
 
     // Issue #78: bind to the configured address (default 127.0.0.1, opt-in 0.0.0.0)
-    // instead of the previously hardcoded 0.0.0.0 (v0.11.0 CR-04).
-    let bind_addr = config.load().bind_addr.clone();
-    let addr = format!("{}:{}", bind_addr, config.load().port);
-    let listener = tokio::net::TcpListener::bind(&addr).await?;
+    // instead of the previously hardcoded 0.0.0.0 (v0.11.0 CR-04). Build a typed
+    // SocketAddr so IPv6 binds (e.g. [::1]) are formatted correctly.
+    let addr = {
+        let cfg = config.load();
+        Config::resolve_socket_addr(&cfg.bind_addr, cfg.port)?
+    };
+    let listener = tokio::net::TcpListener::bind(addr).await?;
 
     // Issue #78: warn loudly when reachable beyond localhost so exposure is never silent.
-    if bind_addr.parse::<std::net::IpAddr>().map(|ip| !ip.is_loopback()).unwrap_or(false) {
+    if !addr.ip().is_loopback() {
         tracing::warn!(
             "[WARN]  NEXUS is bound to {addr} — reachable beyond localhost. Configure your \
              firewall and/or ALLOWED_IPS to restrict who can reach this proxy."

--- a/src/proxy/mod.rs
+++ b/src/proxy/mod.rs
@@ -512,6 +512,7 @@ mod context_window_tests {
     fn make_minimal_config() -> Config {
         Config {
             port: 8315,
+            bind_addr: "127.0.0.1".to_string(),
             base_url: "https://test.example.com".to_string(),
             api_key: Some("test-key".to_string()),
             reasoning_model: None,

--- a/src/transform_test.rs
+++ b/src/transform_test.rs
@@ -14,6 +14,7 @@ mod tests {
     fn test_config() -> Config {
         Config {
             port: 8315,
+            bind_addr: "127.0.0.1".to_string(),
             base_url: "http://localhost:11434".to_string(),
             api_key: None,
             reasoning_model: None,

--- a/src/watcher_test.rs
+++ b/src/watcher_test.rs
@@ -267,11 +267,14 @@ fn reload_accepts_config_path_parameter() {
     // this test won't compile, catching the regression early.
     // We can't call reload() without a valid env, but we verify
     // the function exists with the right parameter count by type-checking.
+    // The verbose fn-pointer type is the whole point of this assertion helper.
+    #[allow(clippy::type_complexity)]
     fn _assert_reload_signature(
         _f: fn(
             bool,
             bool,
             Option<u16>,
+            Option<String>,
             Option<std::path::PathBuf>,
         ) -> anyhow::Result<crate::config::Config>,
     ) {
@@ -292,6 +295,7 @@ fn config_has_config_path_field() {
     // Build a minimal config to verify config_path field exists
     let config = Config {
         port: 8315,
+        bind_addr: "127.0.0.1".to_string(),
         base_url: "http://localhost:11434".to_string(),
         api_key: None,
         reasoning_model: None,
@@ -338,6 +342,7 @@ fn config_path_defaults_to_none() {
 
     let config = Config {
         port: 8315,
+        bind_addr: "127.0.0.1".to_string(),
         base_url: "http://localhost:11434".to_string(),
         api_key: None,
         reasoning_model: None,
@@ -438,7 +443,7 @@ fn reload_preserves_custom_config_path() {
         writeln!(f, "UPSTREAM_API_KEY=test-key").unwrap();
     }
 
-    let cfg = Config::reload(false, false, None, Some(path.clone()))
+    let cfg = Config::reload(false, false, None, None, Some(path.clone()))
         .expect("reload with a custom config path should succeed");
 
     assert_eq!(


### PR DESCRIPTION
## Summary

Closes #108. Follow-up to #78 (`NEXUS listens on 0.0.0.0:8315 — reachable from the whole LAN without authentication`).

Forensic investigation confirmed the bind was **hardcoded** `0.0.0.0` at `src/main.rs` (`// v0.11.0 CR-04`) with **no configuration mechanism** (no env, no CLI flag), plus a misleading dead `HOST` variable. This PR makes the bind **secure-by-default** and adds layered, opt-in exposure controls.

`#64` (SSRF bypass in streaming WebFetch) and `#65` (UTF-8 panic) are intentionally **deferred to Part 2** — they share `streaming.rs`. This PR's loopback default already shrinks their blast radius to localhost.

## What changed (Solutions A–D)

### A — Configurable bind, secure default `[src/config.rs, src/cli.rs, src/main.rs]`
- New `Config.bind_addr`, default **`127.0.0.1`** (loopback-only).
- Read from `BIND_ADDR` env and `--bind` CLI flag (precedence **CLI > env > default**), validated (`parse, don't validate` → invalid falls back to loopback).
- Startup **warning** when bound beyond loopback.
- Legacy `HOST` **deprecated and ignored** (warns when set without `BIND_ADDR`) — it never controlled the listener.
- Bind preserved across hot-reload (`reload()` gains a `cli_bind` parameter, mirroring `cli_port`).

### B — Optional IP allowlist middleware `[src/access_control.rs, src/main.rs]`
- Parses `ALLOWED_IPS` (comma-separated CIDRs/IPs, IPv4+IPv6 via `ipnet`).
- Uses the **already-present** `ConnectInfo<SocketAddr>`; mounted as the outermost layer.
- **Loopback always allowed** (prevents self-DoS / local health checks / CC).
- Empty/unset = allow all (the bind address governs) — zero overhead when unused.

### C — systemd network hardening `[scripts/nexus-ai-gateway.service]`
- Adds `RestrictAddressFamilies=AF_INET AF_INET6 AF_UNIX`.
- **Deliberately does NOT** set `IPAddressDeny=any`: systemd IP filtering is bidirectional and would break this forward proxy's **outbound** calls to NVIDIA NIM. Documented inline.

### D — Explicit firewall script `[scripts/harden-firewall.sh]`
- Idempotent UFW rule for the port (`--dry-run`, `--allow-lan <cidr>`, `--port`), `shellcheck`-clean. Not applied automatically.

## Tests

- **+18 unit tests** (all green): bind config (default/override/IPv6/invalid-fallback/HOST-deprecation), allowlist predicate (CIDR/bare-IP/IPv6/loopback/invalid), and **HTTP middleware** via `oneshot` (`200` allowed / `403` denied / loopback passes).
- Full suite: **358 lib + 4 integration + 3 version_sync = 365 passed, 0 failed**.
- `cargo fmt`, `cargo clippy -- -D warnings`, version 3-file sync: clean.

## Live verification (isolated `:8316`, prod `:8315` untouched)

| Check | Result |
|-------|--------|
| Default bind | `ss` → `LISTEN 127.0.0.1:8316` (not `0.0.0.0`) |
| **Real `claude` via `localhost:8316`** | **`PONG`, exit 0** — CC → NEXUS (loopback) → NIM round-trip works |
| `--bind 0.0.0.0` override | `LISTEN 0.0.0.0:8316` + `[WARN] reachable beyond localhost` |
| Hot-reload | bind preserved at `127.0.0.1` across `.env` reload (exercises `reload(cli_bind)`) |
| Production `:8315` | `active`, untouched throughout |

## Out of scope (reported, not changed here)

Pre-existing items surfaced during the work, kept out to preserve a surgical diff:
- 4 clippy lints in **test modules** visible only under `--all-targets` (CI uses plain `cargo clippy`).
- `Taskfile.yaml` `version-check` task has a YAML parse error.
- systemd `StartLimitIntervalSec`/`StartLimitBurst` are under `[Service]` (should be `[Unit]`).
- The file-watcher reload path merges **all** `.env` files (asymmetric vs. startup's first-match).

## Notes

- `BIND_ADDR`/`ALLOWED_IPS` are read once at startup (not hot-reloaded) — restart to change.
- **Operator action after deploy:** production `~/.nexus-ai-gateway.env` currently has the dead `HOST=0.0.0.0`; the service will now default to `127.0.0.1` (the intended fix). To keep LAN access, set `BIND_ADDR=0.0.0.0` explicitly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `BIND_ADDR` environment variable and `--bind` CLI flag for listener bind address configuration.
  * Added `ALLOWED_IPS` environment variable for optional per-request IP allowlisting.

* **Security Enhancements**
  * Default listener binding changed to loopback-only (127.0.0.1).
  * Added systemd network restrictions to the gateway service unit.
  * Added UFW firewall hardening script for the proxy port.

* **Documentation**
  * Updated environment variable documentation for bind address and IP allowlist configuration.
  * Expanded security policy documentation with network exposure and access control guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->