### PR TITLE
fix(security): make bind/HOST config warnings visible at startup (OSS UX)

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -157,15 +157,17 @@ impl Config {
     }
 
     /// Validate and normalize a bind address (Issue #78).
-    /// Parses the value as an `IpAddr`; on failure logs a warning and falls back
-    /// to the safe loopback default `127.0.0.1` (parse, don't validate).
+    /// Parses the value as an `IpAddr`; on failure warns and falls back to the safe
+    /// loopback default `127.0.0.1` (parse, don't validate).
+    /// Uses `eprintln!` (not `tracing`) because this runs during config construction,
+    /// before the tracing subscriber is initialized — otherwise the warning is lost.
     pub(crate) fn normalize_bind_addr(raw: &str) -> String {
         let trimmed = raw.trim();
         match trimmed.parse::<std::net::IpAddr>() {
             Ok(_) => trimmed.to_string(),
             Err(_) => {
-                tracing::warn!(
-                    "Invalid BIND_ADDR='{}' — not a valid IP address. Falling back to 127.0.0.1 (loopback-only).",
+                eprintln!(
+                    "[WARN] Invalid BIND_ADDR='{}' is not a valid IP address; falling back to 127.0.0.1 (loopback-only).",
                     trimmed
                 );
                 "127.0.0.1".to_string()
@@ -189,8 +191,10 @@ impl Config {
     /// present without `BIND_ADDR`, warn the operator (it never controlled the bind).
     fn resolve_bind_addr(bind_addr_raw: Option<String>, host_raw: Option<String>) -> String {
         if bind_addr_raw.is_none() && host_raw.is_some() {
-            tracing::warn!(
-                "HOST is deprecated and ignored — it never controlled the listener. \
+            // eprintln! (not tracing): emitted during config construction, before the
+            // tracing subscriber exists. OSS users migrating with HOST set must see this.
+            eprintln!(
+                "[WARN] HOST is deprecated and ignored; it never controlled the listener. \
                  Use BIND_ADDR instead (defaulting to 127.0.0.1). \
                  Set BIND_ADDR=0.0.0.0 to expose on all interfaces."
             );

--- a/src/main.rs
+++ b/src/main.rs
@@ -374,11 +374,19 @@ async fn async_main(cli: Cli) -> anyhow::Result<()> {
     let listener = tokio::net::TcpListener::bind(addr).await?;
 
     // Issue #78: warn loudly when reachable beyond localhost so exposure is never silent.
+    // The warning escalates when no ALLOWED_IPS is configured (fully open proxy).
     if !addr.ip().is_loopback() {
-        tracing::warn!(
-            "[WARN]  NEXUS is bound to {addr} — reachable beyond localhost. Configure your \
-             firewall and/or ALLOWED_IPS to restrict who can reach this proxy."
-        );
+        if allowlist_configured {
+            tracing::warn!(
+                "[WARN]  NEXUS is bound to {addr} (reachable beyond localhost); access restricted by ALLOWED_IPS."
+            );
+        } else {
+            tracing::warn!(
+                "[WARN]  NEXUS is bound to {addr} with NO ALLOWED_IPS set - ANY host that can reach this \
+                 address may use the proxy (and spend your upstream API credits). Set ALLOWED_IPS and/or add \
+                 a firewall rule (scripts/harden-firewall.sh)."
+            );
+        }
     }
 
     tracing::info!("Listening on {}", addr);


### PR DESCRIPTION
## Summary
Follow-up polish to the #78 bind hardening, for OSS users running NEXUS in arbitrary environments (VMs, containers, etc.).

The `HOST`-deprecation and invalid-`BIND_ADDR` warnings were emitted via `tracing::warn!` **during config construction — before the tracing subscriber is initialized** (`main.rs` loads config at ~L117, inits tracing at ~L141), so they were **silently dropped**. An OSS user migrating with `HOST=0.0.0.0` in their `.env` would see LAN access "break" with no explanation.

## Changes
- `config.rs`: `normalize_bind_addr` (invalid `BIND_ADDR`) and `resolve_bind_addr` (`HOST` deprecated) now use `eprintln!` (matching the existing config-time warning style, e.g. the `/v1` notice) so they are actually visible at startup.
- `main.rs`: the non-loopback bind warning now **escalates** — when bound beyond localhost with **no `ALLOWED_IPS`**, it states plainly that any reachable host can use the proxy (and spend upstream credits); with `ALLOWED_IPS` it notes access is restricted.

No behavior/return-value change — only warning visibility/wording. Default stays `127.0.0.1`.

## Verified live (`:8316`, prod `:8315` untouched)
| Scenario | Result |
|---|---|
| `HOST=0.0.0.0`, no `BIND_ADDR` | `[WARN] HOST is deprecated...` printed **before** `Listening`; binds `127.0.0.1` |
| `--bind 0.0.0.0`, no `ALLOWED_IPS` | escalated warning: "NO ALLOWED_IPS set - ANY host... may use the proxy" |
| `--bind 0.0.0.0` + `ALLOWED_IPS=192.168.1.0/24` | softer warning: "restricted by ALLOWED_IPS" |

fmt/clippy/unicode/tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved startup warning messages to provide clearer, context-aware guidance based on `ALLOWED_IPS` configuration, distinguishing between restricted and unrestricted network access scenarios and recommending firewall rules where applicable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->