### PR TITLE
security/fix: streaming WebFetch — SSRF guard (#64) + UTF-8 panic (#65) + make web_fetch actually work (A1/A5)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1620,9 +1620,9 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.14"
+version = "0.11.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+checksum = "4fcb935c5bec503c2f0e306bdd3e58bb9029dcb14fa8d9ac76e3a5256ac0763e"
 dependencies = [
  "bytes",
  "getrandom 0.3.4",

--- a/scripts/nexus-ai-gateway.service
+++ b/scripts/nexus-ai-gateway.service
@@ -3,16 +3,20 @@ Description=NEXUS-AI-Gateway — Anthropic-to-NIM Proxy
 Documentation=https://github.com/enerBydev/nexus-ai-gateway
 After=network-online.target
 Wants=network-online.target
+# Crash-loop protection (Issue #72): StartLimit* are honored ONLY in [Unit], not in
+# [Service] (systemd silently ignores them there). Stop restarting after 5 failed
+# starts within 300s instead of looping forever.
+StartLimitIntervalSec=300
+StartLimitBurst=5
 
 [Service]
 Type=simple
 ExecStart=%h/.cargo/bin/nexus-ai-gateway
 ExecReload=/bin/kill -HUP $MAINPID
 Restart=always
-RestartSec=3
-# Prevent restart loops: 5 failures in 60s = stop trying
-StartLimitIntervalSec=60
-StartLimitBurst=5
+# Issue #72: 10s recovery delay (was 3s) so a recurring crash trigger cannot spin a
+# tight restart loop. Pairs with StartLimit* in [Unit] above.
+RestartSec=10
 # Graceful shutdown: only kill main process, let it drain connections
 KillMode=process
 # Aligned with DRAIN_TIMEOUT_SECS=30 + 15s margin

--- a/src/main.rs
+++ b/src/main.rs
@@ -51,6 +51,24 @@ pub static SHUTDOWN_TOKEN: std::sync::LazyLock<CancellationToken> =
     std::sync::LazyLock::new(CancellationToken::new);
 
 fn main() -> anyhow::Result<()> {
+    // Issue #72/#65: log the panic payload + location before the process aborts.
+    // Cargo.toml sets panic="abort", so any panic kills the whole process with no
+    // diagnostic by default. eprintln! (not tracing) because the subscriber may not be
+    // initialized when the panic fires.
+    std::panic::set_hook(Box::new(|info| {
+        let location = info
+            .location()
+            .map(|l| format!("{}:{}:{}", l.file(), l.line(), l.column()))
+            .unwrap_or_else(|| "<unknown location>".to_string());
+        let msg = info
+            .payload()
+            .downcast_ref::<&str>()
+            .map(|s| (*s).to_string())
+            .or_else(|| info.payload().downcast_ref::<String>().cloned())
+            .unwrap_or_else(|| "<non-string panic payload>".to_string());
+        eprintln!("[PANIC] NEXUS panicked at {location}: {msg}");
+    }));
+
     let cli = Cli::parse();
 
     if let Some(command) = cli.command {

--- a/src/proxy/streaming.rs
+++ b/src/proxy/streaming.rs
@@ -107,6 +107,8 @@ pub(crate) async fn handle_streaming(
         cc_context_window, // Issue #28: resolved dynamically
         _circuit_breaker,
         shutdown_token,
+        config.clone(),
+        client.clone(),
     );
 
     let mut headers = HeaderMap::new();
@@ -131,6 +133,10 @@ pub(crate) fn create_sse_stream(
     cc_context_window: u32, // Issue #28: resolved dynamically
     _circuit_breaker: &crate::proxy::concurrency::CircuitBreaker,
     shutdown_token: CancellationToken,
+    // Issue #64/#65 (Solution A): shared HTTP client + config so the streaming WebFetch
+    // interceptor can delegate to web_fetch::execute_fetch() (validated, UTF-8-safe).
+    config: Arc<Config>,
+    client: Client,
 ) -> impl Stream<Item = Result<Bytes, std::io::Error>> + Send {
     async_stream::stream! {
         tracing::debug!(
@@ -280,6 +286,39 @@ pub(crate) fn create_sse_stream(
                         for l in line.lines() {
                             if let Some(data) = l.strip_prefix("data: ") {
                                 if data.trim() == "[DONE]" {
+                                    // Issue #64/#65/A1: flush a pending WebFetch interception. With NIM the
+                                    // finish_reason branch is not reliably reached after a web_fetch tool_call,
+                                    // so without this the interception is abandoned and the model gets nothing
+                                    // (A1). Execute it here via execute_fetch (validated + UTF-8-safe) and emit
+                                    // the content as a self-contained text block. The is_intercepting_fetch
+                                    // guard makes this idempotent with the finish_reason path.
+                                    if is_intercepting_fetch {
+                                        let fetch_url = web_fetch::extract_url_from_raw(&fetch_args_buffer).unwrap_or_default();
+                                        let fetch_result = if fetch_url.is_empty() || !fetch_url.starts_with("http") {
+                                            "Error: Could not extract valid URL".to_string()
+                                        } else {
+                                            tracing::info!("[WebFetch/Stream] Executing fetch for: {} (flushed at [DONE])", fetch_url);
+                                            web_fetch::execute_fetch(&client, &fetch_url, &config)
+                                                .await
+                                                .unwrap_or_else(|e| format!("Error fetching {}: {}", fetch_url, e))
+                                        };
+                                        tracing::info!("[WebFetch/Stream] Fetched {} chars (flushed at [DONE])", fetch_result.len());
+                                        if current_block_type.is_some() {
+                                            let ev = json!({"type": "content_block_stop", "index": content_index});
+                                            yield Ok(Bytes::from(format!("event: content_block_stop\ndata: {}\n\n", serde_json::to_string(&ev).unwrap_or_default())));
+                                            content_index += 1;
+                                        }
+                                        let ev = json!({"type": "content_block_start", "index": content_index, "content_block": {"type": "text", "text": ""}});
+                                        yield Ok(Bytes::from(format!("event: content_block_start\ndata: {}\n\n", serde_json::to_string(&ev).unwrap_or_default())));
+                                        let ev = json!({"type": "content_block_delta", "index": content_index, "delta": {"type": "text_delta", "text": format!("[Fetched content from {}]\n\n{}", fetch_url, fetch_result)}});
+                                        yield Ok(Bytes::from(format!("event: content_block_delta\ndata: {}\n\n", serde_json::to_string(&ev).unwrap_or_default())));
+                                        let ev = json!({"type": "content_block_stop", "index": content_index});
+                                        yield Ok(Bytes::from(format!("event: content_block_stop\ndata: {}\n\n", serde_json::to_string(&ev).unwrap_or_default())));
+                                        content_index += 1;
+                                        current_block_type = None;
+                                        is_intercepting_fetch = false;
+                                        suppressed_block_start = false;
+                                    }
                                     if let Some(ref stop) = saved_stop_reason {
                                         let scaled_delta = scale_token_usage(accumulated_input_tokens, accumulated_output_tokens, upstream_ctx, cc_ctx, "streaming-delta");
                                         let delta_event = json!({
@@ -561,6 +600,12 @@ pub(crate) fn create_sse_stream(
                                                             serde_json::to_string(&event).unwrap_or_default());
                                                         yield Ok(Bytes::from(sse_data));
                                                         content_index += 1;
+                                                        // A5 fix (Issue #64/#65 empirical): reset block state after
+                                                        // closing. Without this, current_block_type stays stale (e.g.
+                                                        // "thinking") and the subsequent WebFetch/text emit double-
+                                                        // closes this already-closed block, emitting an orphan
+                                                        // content_block_stop that CC rejects as "Content block not found".
+                                                        current_block_type = None;
                                                     }
                                                     // Issue #90: sanitize at the source so both the
                                                     // emitted tool_use.id and the web_fetch buffer are valid.
@@ -638,36 +683,18 @@ pub(crate) fn create_sse_stream(
                                                 let fetch_url = web_fetch::extract_url_from_raw(&fetch_args_buffer)
                                                     .unwrap_or_default();
 
+                                                // Issue #64 + #65 (Solution A): delegate to the shared, validated,
+                                                // UTF-8-safe execute_fetch() instead of an ad-hoc client. This
+                                                // inherits is_url_safe() + DNS-aware SSRF guard (no more #64 bypass)
+                                                // and safe_truncate() (no more #65 byte-slice panic), and honors
+                                                // config timeout / content-type handling — mirroring non_streaming.
                                                 let fetch_result = if fetch_url.is_empty() || !fetch_url.starts_with("http") {
                                                     "Error: Could not extract valid URL".to_string()
                                                 } else {
                                                     tracing::info!("[WebFetch/Stream] Executing fetch for: {}", fetch_url);
-                                                    let fetch_client = reqwest::Client::builder()
-                                                        .timeout(std::time::Duration::from_secs(15))
-                                                        .build()
-                                                        .unwrap_or_else(|_| reqwest::Client::new());
-
-                                                    match fetch_client
-                                                        .get(&fetch_url)
-                                                        .header("User-Agent", "Mozilla/5.0")
-                                                        .send()
+                                                    web_fetch::execute_fetch(&client, &fetch_url, &config)
                                                         .await
-                                                    {
-                                                        Ok(resp) => {
-                                                            match resp.text().await {
-                                                                Ok(body) => {
-                                                                    let text = web_fetch::strip_html_tags(&body);
-                                                                    if text.len() > 200_000 {
-                                                                        format!("{}\n\n[Content truncated]", &text[..200_000])
-                                                                    } else {
-                                                                        text
-                                                                    }
-                                                                }
-                                                                Err(e) => format!("Error reading response: {}", e),
-                                                            }
-                                                        }
-                                                        Err(e) => format!("Error fetching {}: {}", fetch_url, e),
-                                                    }
+                                                        .unwrap_or_else(|e| format!("Error fetching {}: {}", fetch_url, e))
                                                 };
 
                                                 tracing::info!("[WebFetch/Stream] Fetched {} chars", fetch_result.len());

--- a/src/proxy/streaming.rs
+++ b/src/proxy/streaming.rs
@@ -318,6 +318,14 @@ pub(crate) fn create_sse_stream(
                                         current_block_type = None;
                                         is_intercepting_fetch = false;
                                         suppressed_block_start = false;
+                                        // CodeRabbit: when the finish_reason branch never ran (the common NIM
+                                        // web_fetch case), saved_stop_reason is None and the terminal
+                                        // message_delta (stop_reason + scaled usage) below would be skipped.
+                                        // Set it so the stream ends with a proper message_delta, matching the
+                                        // non-streaming contract.
+                                        if saved_stop_reason.is_none() {
+                                            saved_stop_reason = Some("end_turn".to_string());
+                                        }
                                     }
                                     if let Some(ref stop) = saved_stop_reason {
                                         let scaled_delta = scale_token_usage(accumulated_input_tokens, accumulated_output_tokens, upstream_ctx, cc_ctx, "streaming-delta");

--- a/src/web_fetch.rs
+++ b/src/web_fetch.rs
@@ -127,11 +127,17 @@ async fn verify_host_resolves_public(url: &str) -> Result<(), String> {
     }
 
     // Hostname: resolve and verify EVERY returned address is public.
+    // CodeRabbit: bound the DNS lookup so a slow/unresponsive authoritative nameserver
+    // (attacker-controlled, since fetches are model-driven) cannot stall the request path.
     let port = parsed.port_or_known_default().unwrap_or(80);
-    let addrs: Vec<std::net::SocketAddr> = tokio::net::lookup_host((host, port))
-        .await
-        .map_err(|e| format!("DNS resolution failed for '{host}': {e}"))?
-        .collect();
+    let addrs: Vec<std::net::SocketAddr> = tokio::time::timeout(
+        std::time::Duration::from_secs(5),
+        tokio::net::lookup_host((host, port)),
+    )
+    .await
+    .map_err(|_| format!("DNS resolution timed out for '{host}'"))?
+    .map_err(|e| format!("DNS resolution failed for '{host}': {e}"))?
+    .collect();
     if addrs.is_empty() {
         return Err(format!("'{host}' resolved to no addresses"));
     }

--- a/src/web_fetch.rs
+++ b/src/web_fetch.rs
@@ -79,22 +79,68 @@ fn is_url_safe(url: &str) -> bool {
     true
 }
 
-/// Check if an IP address is in RFC1918 private ranges
-#[allow(dead_code)]
+/// True if `ip` is loopback, unspecified, private (RFC1918/ULA), link-local/CGNAT, or
+/// otherwise unsafe to fetch from (SSRF guard, Issue #64). IPv4-mapped IPv6 (e.g.
+/// `::ffff:127.0.0.1`) is canonicalized to its IPv4 form first so it cannot bypass the check.
 fn is_private_ip(ip: IpAddr) -> bool {
-    let private_ranges: &[&str] = &[
-        "10.0.0.0/8",
-        "172.16.0.0/12",
-        "192.168.0.0/16",
-        "127.0.0.0/8",
-        "169.254.0.0/16",
-        "::1/128",
-        "fc00::/7",
-        "fe80::/10",
+    // Canonicalize IPv4-mapped IPv6 to IPv4 (defeats `::ffff:<private>` bypass).
+    let ip = match ip {
+        IpAddr::V6(v6) => v6.to_ipv4_mapped().map(IpAddr::V4).unwrap_or(IpAddr::V6(v6)),
+        v4 => v4,
+    };
+    if ip.is_loopback() || ip.is_unspecified() {
+        return true;
+    }
+    const BLOCKED: &[&str] = &[
+        "0.0.0.0/8",      // "this network"
+        "10.0.0.0/8",     // RFC1918
+        "100.64.0.0/10",  // CGNAT (RFC6598)
+        "127.0.0.0/8",    // loopback
+        "169.254.0.0/16", // link-local / cloud metadata (AWS/GCP/Azure)
+        "172.16.0.0/12",  // RFC1918
+        "192.168.0.0/16", // RFC1918
+        "::1/128",        // IPv6 loopback
+        "fc00::/7",       // IPv6 unique local (ULA)
+        "fe80::/10",      // IPv6 link-local
     ];
-    private_ranges
-        .iter()
-        .any(|cidr| cidr.parse::<ipnet::IpNet>().is_ok_and(|net| net.contains(&ip)))
+    BLOCKED.iter().any(|cidr| cidr.parse::<ipnet::IpNet>().is_ok_and(|net| net.contains(&ip)))
+}
+
+/// DNS-aware SSRF defense (Issue #64): resolve the URL host and reject if any resolved
+/// address is private/loopback/link-local. Closes the DNS-rebinding and numeric-encoding
+/// bypasses that the string-prefix `is_url_safe()` cannot catch (e.g. a public domain that
+/// resolves to `127.0.0.1`, or `127-0-0-1.nip.io`).
+///
+/// Note: a strict TOCTOU gap remains between resolve and connect; for the proxy's threat
+/// model (model-driven fetches) this DNS check plus `is_url_safe()` is a strong mitigation.
+async fn verify_host_resolves_public(url: &str) -> Result<(), String> {
+    let parsed = reqwest::Url::parse(url).map_err(|e| format!("invalid URL: {e}"))?;
+    let host = parsed.host_str().ok_or_else(|| "URL has no host".to_string())?;
+
+    // Host is an IP literal (IPv4 or IPv6): validate directly, no DNS needed.
+    if let Ok(ip) = host.parse::<IpAddr>() {
+        return if is_private_ip(ip) {
+            Err(format!("host is a private/loopback IP ({ip})"))
+        } else {
+            Ok(())
+        };
+    }
+
+    // Hostname: resolve and verify EVERY returned address is public.
+    let port = parsed.port_or_known_default().unwrap_or(80);
+    let addrs: Vec<std::net::SocketAddr> = tokio::net::lookup_host((host, port))
+        .await
+        .map_err(|e| format!("DNS resolution failed for '{host}': {e}"))?
+        .collect();
+    if addrs.is_empty() {
+        return Err(format!("'{host}' resolved to no addresses"));
+    }
+    for addr in &addrs {
+        if is_private_ip(addr.ip()) {
+            return Err(format!("'{host}' resolves to private/loopback IP {}", addr.ip()));
+        }
+    }
+    Ok(())
 }
 
 /// Ejecuta HTTP GET y devuelve contenido como texto
@@ -113,11 +159,21 @@ pub async fn execute_fetch(
         )));
     }
 
-    // v0.11.0 (CR-05): SSRF protection — block internal/metadata IPs
+    // v0.11.0 (CR-05): SSRF protection — fast string pre-filter (internal/metadata hosts).
     if !is_url_safe(url) {
         tracing::warn!("[GUARD] SSRF blocked: {}", url);
         return Err(ProxyError::WebFetch(format!(
             "URL blocked by security policy (internal/metadata address): {}",
+            url
+        )));
+    }
+
+    // Issue #64: DNS-aware SSRF guard — resolve the host and reject private/loopback IPs.
+    // Closes DNS rebinding and numeric-encoding bypasses the string filter above misses.
+    if let Err(reason) = verify_host_resolves_public(url).await {
+        tracing::warn!("[GUARD] SSRF blocked ({}): {}", reason, url);
+        return Err(ProxyError::WebFetch(format!(
+            "URL blocked by security policy (resolves to internal address): {}",
             url
         )));
     }
@@ -402,5 +458,46 @@ mod tests {
         // Public IPs should be allowed
         assert!(!is_private_ip(IpAddr::V4(Ipv4Addr::new(8, 8, 8, 8))));
         assert!(!is_private_ip(IpAddr::V4(Ipv4Addr::new(1, 1, 1, 1))));
+    }
+
+    // Issue #64: extended SSRF coverage — encodings, IPv6, IPv4-mapped, CGNAT, link-local.
+    #[test]
+    fn test_private_ip_extended_vectors() {
+        use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
+        // Unspecified / "this network"
+        assert!(is_private_ip(IpAddr::V4(Ipv4Addr::new(0, 0, 0, 0))));
+        assert!(is_private_ip(IpAddr::V6(Ipv6Addr::UNSPECIFIED)));
+        // Link-local / cloud metadata
+        assert!(is_private_ip(IpAddr::V4(Ipv4Addr::new(169, 254, 169, 254))));
+        // CGNAT
+        assert!(is_private_ip(IpAddr::V4(Ipv4Addr::new(100, 64, 0, 1))));
+        // IPv6 ULA + link-local
+        assert!(is_private_ip("fc00::1".parse().unwrap()));
+        assert!(is_private_ip("fe80::1".parse().unwrap()));
+        // IPv4-mapped IPv6 of a loopback address must be caught (canonicalization)
+        assert!(is_private_ip("::ffff:127.0.0.1".parse().unwrap()));
+        assert!(is_private_ip("::ffff:10.0.0.1".parse().unwrap()));
+        // Public IPv4-mapped is still public
+        assert!(!is_private_ip("::ffff:8.8.8.8".parse().unwrap()));
+        // Public IPv6
+        assert!(!is_private_ip("2606:4700:4700::1111".parse().unwrap()));
+    }
+
+    #[tokio::test]
+    async fn test_verify_host_resolves_public_blocks_internal() {
+        // IP literals (no DNS)
+        assert!(verify_host_resolves_public("http://127.0.0.1/admin").await.is_err());
+        assert!(verify_host_resolves_public("http://169.254.169.254/latest/").await.is_err());
+        assert!(verify_host_resolves_public("http://[::1]:8080/").await.is_err());
+        assert!(verify_host_resolves_public("http://0.0.0.0/").await.is_err());
+        // Hostname that resolves to loopback (reliable via /etc/hosts, no external network)
+        assert!(verify_host_resolves_public("http://localhost:8899/poison").await.is_err());
+    }
+
+    #[tokio::test]
+    async fn test_verify_host_resolves_public_allows_public_ip_literals() {
+        // Public IP literals resolve fine without DNS.
+        assert!(verify_host_resolves_public("http://8.8.8.8/").await.is_ok());
+        assert!(verify_host_resolves_public("https://1.1.1.1/").await.is_ok());
     }
 }


### PR DESCRIPTION
## Summary

Closes #113. Fixes **#64** (SSRF bypass) and **#65** (UTF-8 panic) in the streaming WebFetch interceptor, plus four anomalies discovered during **live empirical testing** with real Claude Code → NEXUS → NVIDIA NIM.

Root cause: the streaming WebFetch path (`src/proxy/streaming.rs`) was a **divergent reimplementation** of the safe `web_fetch::execute_fetch()` used by the non-streaming path — it skipped `is_url_safe()` (#64) and truncated with `&text[..200_000]` (#65, which under `panic="abort"` kills the whole process).

## What the empirical testing revealed (and this PR fixes)

| ID | Finding | Fix |
|----|---------|-----|
| **#64** | Streaming fetch had no SSRF validation | Converge to `execute_fetch()` + DNS-aware guard |
| **#65** | `&text[..200_000]` byte-slice panics on multibyte UTF-8 → whole-process abort | `execute_fetch()` uses `safe_truncate()`; byte-slice removed |
| **A1** | Interception started but the fetch **never executed** with NIM (`web_fetch` silently returned nothing) — the `finish_reason` branch is not reliably reached | Flush the pending fetch at `[DONE]` (idempotent with `finish_reason` via the `is_intercepting_fetch` guard) |
| **A5** | Once the fetch executed, an **orphan `content_block_stop`** was emitted (`current_block_type` left stale after closing a thinking block) → CC rejected with **"Content block not found"** | Reset `current_block_type = None` after closing a block on tool_call start |
| **A3** | The model itself avoids `web_fetch` for literal-internal URLs (uses curl) — a non-security, model-dependent partial mitigation | Documented; not relied upon |
| **A4** | `is_url_safe()` evadable via DNS rebinding (`127-0-0-1.nip.io` → loopback) + IP encodings + incomplete IPv6 | Hardened (below) |

## Changes (Solutions A / B / C)

### A — Converge streaming → `execute_fetch()` `[streaming.rs]`
Delegate the fetch to the shared, validated, UTF-8-safe path instead of an ad-hoc `reqwest` client + byte slice (thread `config`+`client` into `create_sse_stream`). Plus the **A1** `[DONE]` flush and the **A5** block-state reset.

### B — DNS-aware SSRF guard `[web_fetch.rs]`
- Resurrect `is_private_ip()` (was `#[allow(dead_code)]`) and harden it: canonicalize IPv4-mapped IPv6, add `0.0.0.0/8`, CGNAT, loopback/unspecified, IPv6 ULA/link-local.
- New `verify_host_resolves_public()`: resolve the host and reject if any resolved IP is private/loopback — closes rebinding + numeric encodings. Wired into `execute_fetch()`.

### C — Resilience (couples #72) `[main.rs, .service]`
- `std::panic::set_hook` logs payload + location before the `panic="abort"` process death.
- systemd: move `StartLimit*` to `[Unit]` (ignored in `[Service]`) + `RestartSec 3 → 10` so crash-loop protection is effective.

### deps `[Cargo.lock]`
Bump pre-existing transitive `quinn-proto 0.11.14 → 0.11.15` (RUSTSEC-2026-0185; HTTP/3 not enabled, not compiled) to keep CI `cargo audit` green.

## Live verification (isolated `:8316`, real `claude`, prod `:8315` untouched)

- ✅ **`web_fetch` now works end-to-end**: `claude` fetched `example.com` and returned its content (`exit 0`). SSE content blocks balanced (2 starts / 2 stops) — no "Content block not found".
- ✅ Fetch executes via the `[DONE]` flush (`Fetched 144 chars (flushed at [DONE])`).
- ✅ **#65 structurally fixed**: zero byte-slices remain in `streaming.rs`; process did not panic.
- ✅ **#64**: SSRF guard unit-tested (blocks `127.0.0.1`, `169.254.169.254`, `::1`, `0.0.0.0`, `localhost`) and now enforced on the streaming path. (Model-driven internal fetch couldn't be triggered — A3 — so this is verified at the code/unit level.)

## Tests / quality

`cargo test` 373 green (+4 new), `clippy -D warnings` clean, fmt + unicode clean, `cargo audit` clean, `systemd-analyze verify` clean.

## Out of scope (noted)

- Full #72 (core dumps, safe-mode) — only the minimal subset (panic hook + systemd) here.
- #62 (retry asymmetry) — same root pattern, separate.
- `UPSTREAM_API_KEY_FILE` secret-file convention — separate enhancement.

## Reference

Forensic + empirical investigation: `docs/Issues-locales/Issues/64-65/` (00–04). Origin: #64, #65.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved crash diagnostics by capturing panic details (payload and source location) before aborting.
  * Fixed SSE stream block-state handling to prevent duplicated or invalid end events during tool-call scenarios.

* **Security**
  * Strengthened SSRF protection with broader private/unsafe IP detection and DNS-aware host resolution to prevent requests that resolve to internal addresses.

* **Reliability**
  * Updated service restart-crash limits and increased restart delay for more stable recovery.
  * Enhanced SSE handling to ensure in-progress fetch interception flushes correctly and streams complete fetched content.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->