### PR TITLE
feat(security): support *_FILE convention to load API keys from a file (#115)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -150,12 +150,15 @@ These behaviors are intentional and should not be changed:
 
 12. **Telemetry always-on BY DESIGN** — Telemetry is enabled by default (v0.19.0+). Local SQLite analytics with HMAC-SHA256 fingerprinting (instance-specific secret) runs without configuration. Daily beacon to CF Worker sends only aggregated stats (zero PII). Users can disable with `TELEMETRY_ENABLED=false` or `TELEMETRY_BEACON_URL=""`.
 
+13. **`*_FILE` secret resolution BY DESIGN** (Issue #115) — `resolve_secret()` lets any API key (`UPSTREAM_API_KEY`, `OPENROUTER_API_KEY`, `UPSTREAM_BIGMODEL_API_KEY`, `UPSTREAM_CF_API_KEY`) be loaded from a file via a `*_FILE` sibling. Precedence: non-empty direct value > trimmed file contents > `None`. Empty/unreadable files warn and fall through (never abort — another source may cover). Both load paths (`from_map` hot-reload, `from_env_with_path` startup) call it, so behavior is identical on startup and reload. Uses `eprintln!` (config built before tracing exists) and never logs the secret — only the path.
+
 ## Key Environment Variables
 
 | Variable | Default | Purpose |
 |----------|---------|---------|
 | `UPSTREAM_BASE_URL` | (required) | Upstream API endpoint URL |
-| `UPSTREAM_API_KEY` | (required) | API key for upstream service |
+| `UPSTREAM_API_KEY` | (required) | API key for upstream service. Also loadable from a file via `UPSTREAM_API_KEY_FILE` (Issue #115) |
+| `<KEY>_FILE` | (none) | Load any API key from a file (trimmed contents). Applies to `UPSTREAM_API_KEY`, `OPENROUTER_API_KEY`, `UPSTREAM_BIGMODEL_API_KEY`, `UPSTREAM_CF_API_KEY`. Direct value wins when both set; empty/unreadable file warns and is ignored. Same behavior at startup and on hot-reload |
 | `NEXUS_UPSTREAM_TYPE` | `nim` | Upstream type: `anthropic`, `nim`, `openai`, `openrouter` |
 | `UPSTREAM_<NAME>_TYPE` | (falls back to `NEXUS_UPSTREAM_TYPE`) | Per-upstream type override. `<NAME>` matches the upstream name (e.g., `UPSTREAM_BIGMODEL_TYPE=anthropic`). Overrides global `NEXUS_UPSTREAM_TYPE` for that upstream |
 | `PORT` | `8315` | Server port |

--- a/README.md
+++ b/README.md
@@ -175,7 +175,14 @@ flowchart TB
 | Variable | Default | Description |
 |----------|---------|-------------|
 | `UPSTREAM_BASE_URL` | — | OpenAI-compatible API endpoint |
-| `UPSTREAM_API_KEY` | — | Authentication key for upstream (or `OPENROUTER_API_KEY`) |
+| `UPSTREAM_API_KEY` | — | Authentication key for upstream (or `OPENROUTER_API_KEY`). Also loadable from a file via `UPSTREAM_API_KEY_FILE` |
+
+> **Secret from file (Issue #115):** any API-key variable accepts a `*_FILE` sibling
+> (`UPSTREAM_API_KEY_FILE`, `OPENROUTER_API_KEY_FILE`, `UPSTREAM_BIGMODEL_API_KEY_FILE`,
+> `UPSTREAM_CF_API_KEY_FILE`) pointing at a file whose trimmed contents are the secret —
+> ideal for Docker/Kubernetes secrets and systemd `LoadCredential=`. The direct value
+> wins when both are set; an empty/unreadable file is warned and ignored. See
+> [SECURITY.md](SECURITY.md#secret-management--_file-convention-issue-115).
 
 #### Server
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -13,6 +13,7 @@ Do NOT file public issues for security vulnerabilities.
 
 ## Security Features
 - API keys stored in .env files (never hardcoded)
+- **Secret-from-file convention** (`*_FILE`) — load keys from files/secret managers instead of the environment (Issue #115)
 - **Loopback-only bind by default** (`BIND_ADDR=127.0.0.1`) — not reachable from the network unless opted in
 - **Optional IP allowlist** (`ALLOWED_IPS`) — per-request access control, defense-in-depth
 - SSRF protection in WebFetch (RFC1918 IP blocking)
@@ -20,6 +21,37 @@ Do NOT file public issues for security vulnerabilities.
 - Circuit breaker for cascade failure prevention
 - .env file permissions set to 600 on Unix
 - systemd `RestrictAddressFamilies` network hardening
+
+## Secret Management — `*_FILE` convention (Issue #115)
+
+Every API-key variable accepts a `*_FILE` sibling that points at a file whose
+trimmed contents are used as the secret. This keeps credentials out of the
+process environment (not visible via `ps -E`, `/proc/<pid>/environ`, or a leaked
+`.env`) and maps directly onto Docker/Compose secrets, Kubernetes secret volumes,
+and systemd `LoadCredential=`, which all surface secrets as files.
+
+| Direct variable | File variable |
+|-----------------|---------------|
+| `UPSTREAM_API_KEY` | `UPSTREAM_API_KEY_FILE` |
+| `OPENROUTER_API_KEY` | `OPENROUTER_API_KEY_FILE` |
+| `UPSTREAM_BIGMODEL_API_KEY` | `UPSTREAM_BIGMODEL_API_KEY_FILE` |
+| `UPSTREAM_CF_API_KEY` | `UPSTREAM_CF_API_KEY_FILE` |
+
+**Precedence:** a non-empty direct value always wins; the file is read only when
+the direct variable is unset or empty. If both are set, the direct value is used
+and a warning is logged. An empty or unreadable file logs a warning and is
+ignored (the proxy never logs the secret itself — only the path). Resolution is
+identical at startup and on hot-reload (SIGHUP / `.env` watcher).
+
+```bash
+# Docker / Kubernetes mount secrets as files under /run/secrets
+UPSTREAM_API_KEY_FILE=/run/secrets/upstream_api_key
+
+# systemd: expose a credential and point the proxy at it
+#   [Service]
+#   LoadCredential=upstream_key:/etc/nexus/upstream.key
+#   Environment=UPSTREAM_API_KEY_FILE=%d/upstream_key
+```
 
 ## Network Exposure & Access Control (Issue #78)
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -156,6 +156,41 @@ impl Config {
         map.get(key).cloned()
     }
 
+    /// Resolve a secret using the `*_FILE` convention (Issue #115).
+    /// Precedence: a non-empty `direct` value > the trimmed contents of the file at
+    /// `file_path` > `None`. Bridges Docker/Kubernetes secrets, systemd `LoadCredential`
+    /// and Vault Agent, which all expose secrets as files.
+    ///
+    /// Empty files and read errors warn and fall through (never abort — another source
+    /// may cover). Uses `eprintln!` because config is built before the tracing subscriber
+    /// exists (lesson from #78), and never logs the secret itself — only the path.
+    fn resolve_secret(direct: Option<String>, file_path: Option<String>) -> Option<String> {
+        if let Some(v) = direct.filter(|s| !s.is_empty()) {
+            if file_path.as_deref().is_some_and(|p| !p.trim().is_empty()) {
+                eprintln!(
+                    "[WARN] both a direct secret and its *_FILE were set; using the direct value"
+                );
+            }
+            return Some(v);
+        }
+        let path = file_path.filter(|p| !p.trim().is_empty())?;
+        match std::fs::read_to_string(&path) {
+            Ok(content) => {
+                let secret = content.trim().to_string();
+                if secret.is_empty() {
+                    eprintln!("[WARN] secret file '{path}' is empty; ignoring");
+                    None
+                } else {
+                    Some(secret)
+                }
+            }
+            Err(e) => {
+                eprintln!("[WARN] could not read secret file '{path}': {e}");
+                None
+            }
+        }
+    }
+
     /// Validate and normalize a bind address (Issue #78).
     /// Parses the value as an `IpAddr`; on failure warns and falls back to the safe
     /// loopback default `127.0.0.1` (parse, don't validate).
@@ -260,9 +295,17 @@ impl Config {
             )
         })?;
 
-        let api_key = Self::get_from_map(data, "UPSTREAM_API_KEY")
-            .or_else(|| Self::get_from_map(data, "OPENROUTER_API_KEY"))
-            .filter(|k| !k.is_empty());
+        // Issue #115: support the *_FILE convention (direct value > _FILE > none).
+        let api_key = Self::resolve_secret(
+            Self::get_from_map(data, "UPSTREAM_API_KEY"),
+            Self::get_from_map(data, "UPSTREAM_API_KEY_FILE"),
+        )
+        .or_else(|| {
+            Self::resolve_secret(
+                Self::get_from_map(data, "OPENROUTER_API_KEY"),
+                Self::get_from_map(data, "OPENROUTER_API_KEY_FILE"),
+            )
+        });
 
         let reasoning_model = Self::get_from_map(data, "REASONING_MODEL");
         let completion_model = Self::get_from_map(data, "COMPLETION_MODEL");
@@ -313,7 +356,10 @@ impl Config {
                 "bigmodel".to_string(),
                 UpstreamConfig {
                     base_url: bm_url,
-                    api_key: Self::get_from_map(data, "UPSTREAM_BIGMODEL_API_KEY"),
+                    api_key: Self::resolve_secret(
+                        Self::get_from_map(data, "UPSTREAM_BIGMODEL_API_KEY"),
+                        Self::get_from_map(data, "UPSTREAM_BIGMODEL_API_KEY_FILE"),
+                    ),
                     upstream_type: bm_type,
                 },
             );
@@ -330,7 +376,10 @@ impl Config {
                 "cf".to_string(),
                 UpstreamConfig {
                     base_url: cf_url,
-                    api_key: Self::get_from_map(data, "UPSTREAM_CF_API_KEY"),
+                    api_key: Self::resolve_secret(
+                        Self::get_from_map(data, "UPSTREAM_CF_API_KEY"),
+                        Self::get_from_map(data, "UPSTREAM_CF_API_KEY_FILE"),
+                    ),
                     upstream_type: cf_type,
                 },
             );
@@ -619,10 +668,17 @@ impl Config {
             )
         })?;
 
-        let api_key = env::var("UPSTREAM_API_KEY")
-            .or_else(|_| env::var("OPENROUTER_API_KEY"))
-            .ok()
-            .filter(|k| !k.is_empty());
+        // Issue #115: support the *_FILE convention (direct value > _FILE > none).
+        let api_key = Self::resolve_secret(
+            env::var("UPSTREAM_API_KEY").ok(),
+            env::var("UPSTREAM_API_KEY_FILE").ok(),
+        )
+        .or_else(|| {
+            Self::resolve_secret(
+                env::var("OPENROUTER_API_KEY").ok(),
+                env::var("OPENROUTER_API_KEY_FILE").ok(),
+            )
+        });
 
         let reasoning_model = env::var("REASONING_MODEL").ok();
         let completion_model = env::var("COMPLETION_MODEL").ok();
@@ -670,7 +726,10 @@ impl Config {
                 "bigmodel".to_string(),
                 UpstreamConfig {
                     base_url: bm_url,
-                    api_key: env::var("UPSTREAM_BIGMODEL_API_KEY").ok(),
+                    api_key: Self::resolve_secret(
+                        env::var("UPSTREAM_BIGMODEL_API_KEY").ok(),
+                        env::var("UPSTREAM_BIGMODEL_API_KEY_FILE").ok(),
+                    ),
                     upstream_type: bm_type,
                 },
             );
@@ -687,7 +746,10 @@ impl Config {
                 "cf".to_string(),
                 UpstreamConfig {
                     base_url: cf_url,
-                    api_key: env::var("UPSTREAM_CF_API_KEY").ok(),
+                    api_key: Self::resolve_secret(
+                        env::var("UPSTREAM_CF_API_KEY").ok(),
+                        env::var("UPSTREAM_CF_API_KEY_FILE").ok(),
+                    ),
                     upstream_type: cf_type,
                 },
             );
@@ -1250,5 +1312,88 @@ mod tests {
     #[test]
     fn test_resolve_socket_addr_invalid_errors() {
         assert!(Config::resolve_socket_addr("not-an-ip", 8315).is_err());
+    }
+
+    // =========================================================================
+    // Issue #115: *_FILE secret resolution
+    // =========================================================================
+
+    #[test]
+    fn test_resolve_secret_direct_value() {
+        assert_eq!(Config::resolve_secret(Some("k".into()), None), Some("k".to_string()));
+    }
+
+    #[test]
+    fn test_resolve_secret_direct_wins_over_file() {
+        // A non-empty direct value wins even if a (here, nonexistent) file is given.
+        assert_eq!(
+            Config::resolve_secret(Some("direct".into()), Some("/no/such/file".into())),
+            Some("direct".to_string())
+        );
+    }
+
+    #[test]
+    fn test_resolve_secret_reads_and_trims_file() {
+        let path = std::env::temp_dir().join(format!(
+            "nexus-secret-{}-{}.txt",
+            std::process::id(),
+            line!()
+        ));
+        std::fs::write(&path, "  file-secret\n\n").unwrap();
+        let got = Config::resolve_secret(None, Some(path.to_string_lossy().to_string()));
+        let _ = std::fs::remove_file(&path);
+        assert_eq!(got, Some("file-secret".to_string()));
+    }
+
+    #[test]
+    fn test_resolve_secret_empty_file_is_none() {
+        let path = std::env::temp_dir().join(format!(
+            "nexus-secret-empty-{}-{}.txt",
+            std::process::id(),
+            line!()
+        ));
+        std::fs::write(&path, "   \n").unwrap();
+        let got = Config::resolve_secret(None, Some(path.to_string_lossy().to_string()));
+        let _ = std::fs::remove_file(&path);
+        assert_eq!(got, None);
+    }
+
+    #[test]
+    fn test_resolve_secret_missing_file_and_all_none() {
+        assert_eq!(Config::resolve_secret(None, Some("/no/such/file/xyz".into())), None);
+        assert_eq!(Config::resolve_secret(None, None), None);
+        // Empty direct + empty file path both degrade to None.
+        assert_eq!(Config::resolve_secret(Some(String::new()), Some(String::new())), None);
+    }
+
+    #[test]
+    fn test_from_map_loads_api_key_from_file() {
+        let path = std::env::temp_dir().join(format!(
+            "nexus-upstream-key-{}-{}.txt",
+            std::process::id(),
+            line!()
+        ));
+        std::fs::write(&path, "secret-from-file\n").unwrap();
+        let mut map = make_test_map();
+        map.remove("UPSTREAM_API_KEY"); // only the _FILE variant present
+        map.insert("UPSTREAM_API_KEY_FILE".to_string(), path.to_string_lossy().to_string());
+        let config = Config::from_map(&map).unwrap();
+        let _ = std::fs::remove_file(&path);
+        assert_eq!(config.api_key, Some("secret-from-file".to_string()));
+    }
+
+    #[test]
+    fn test_from_map_direct_key_wins_over_file() {
+        let path = std::env::temp_dir().join(format!(
+            "nexus-upstream-key2-{}-{}.txt",
+            std::process::id(),
+            line!()
+        ));
+        std::fs::write(&path, "from-file\n").unwrap();
+        let mut map = make_test_map(); // has UPSTREAM_API_KEY=test-key
+        map.insert("UPSTREAM_API_KEY_FILE".to_string(), path.to_string_lossy().to_string());
+        let config = Config::from_map(&map).unwrap();
+        let _ = std::fs::remove_file(&path);
+        assert_eq!(config.api_key, Some("test-key".to_string()));
     }
 }


### PR DESCRIPTION
## Summary

Adds the **`*_FILE` secret convention** so any upstream API key can be loaded from a file instead of an environment variable. This keeps credentials out of the process environment — not visible via `ps -E`, `/proc/<pid>/environ`, or a leaked `.env` — and maps directly onto **Docker/Compose secrets**, **Kubernetes secret volumes**, and **systemd `LoadCredential=`**, which all surface secrets as files.

Closes #115.

## Design

A single helper, `Config::resolve_secret(direct, file_path)`:

- **Precedence:** non-empty direct value > trimmed file contents > `None`
- If **both** are set → uses the direct value and logs a warning
- Empty or unreadable file → warns and falls through (never aborts — another source may cover)
- **Never logs the secret**, only the path. Uses `eprintln!` because config is built before the tracing subscriber exists (lesson from #78)

Applied to all four keys across **both** load paths so behavior is identical at startup and on hot-reload (SIGHUP / `.env` watcher):

| Direct variable | File variable |
|-----------------|---------------|
| `UPSTREAM_API_KEY` | `UPSTREAM_API_KEY_FILE` |
| `OPENROUTER_API_KEY` | `OPENROUTER_API_KEY_FILE` |
| `UPSTREAM_BIGMODEL_API_KEY` | `UPSTREAM_BIGMODEL_API_KEY_FILE` |
| `UPSTREAM_CF_API_KEY` | `UPSTREAM_CF_API_KEY_FILE` |

- `from_map` (hot-reload): 3 sites
- `from_env_with_path` (startup): 3 sites
- Redundant `.filter(|k| !k.is_empty())` removed from the two `UPSTREAM/OPENROUTER` sites (now handled inside `resolve_secret`)

## Files

- `src/config.rs` — `resolve_secret()` + 6 call sites + 7 tests
- `README.md`, `SECURITY.md`, `CLAUDE.md` — documentation incl. Docker/Kubernetes/systemd examples

## Test plan

- [x] **Unit (5):** direct value; direct-wins-over-file; reads+trims file; empty file → None; missing file / all-None
- [x] **Integration (2):** `from_map` loads key from `UPSTREAM_API_KEY_FILE`; direct key wins when both set
- [x] Full suite: **380 tests, 0 failures**
- [x] `cargo fmt --check` clean · `cargo clippy -- -D warnings` clean (CI-exact) · `cargo audit` clean
- [x] **Live end-to-end:** isolated `:8316` instance with the key loaded **strictly from a file** (no direct `UPSTREAM_API_KEY` anywhere) → real `claude` returned a valid response (`FILEKEY_OK`), upstream auth accepted (no 401), **zero key leakage in logs**. Production `:8315` untouched; temp secret shredded.

## Notes

- `.env.example` carries an annotated example block locally, but it is gitignored in this repo (`.env.*`), so the canonical documentation lives in README/SECURITY/CLAUDE.md.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * API keys can now be loaded from files using `*_FILE` environment variables in addition to direct environment values, supporting multiple API key variables including `UPSTREAM_API_KEY`, `OPENROUTER_API_KEY`, and others.

* **Documentation**
  * Updated documentation describing the new file-based secret convention, precedence rules, warning behavior for empty/unreadable files, and usage examples.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->