### PR TITLE
fix(observability): capture backtrace in panic hook (#72)

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -50,11 +50,19 @@ use tokio_util::sync::CancellationToken;
 pub static SHUTDOWN_TOKEN: std::sync::LazyLock<CancellationToken> =
     std::sync::LazyLock::new(CancellationToken::new);
 
+/// Format the crash diagnostic emitted by the panic hook (Issue #72). Kept as a pure
+/// function so it can be unit-tested — the hook itself cannot be, because Cargo.toml sets
+/// `panic="abort"`, which aborts the test process before any assertion runs.
+fn format_panic_report(location: &str, msg: &str, backtrace: &str) -> String {
+    format!("[PANIC] NEXUS panicked at {location}: {msg}\n[PANIC] backtrace:\n{backtrace}")
+}
+
 fn main() -> anyhow::Result<()> {
-    // Issue #72/#65: log the panic payload + location before the process aborts.
-    // Cargo.toml sets panic="abort", so any panic kills the whole process with no
+    // Issue #72/#65: log the panic payload + location + backtrace before the process
+    // aborts. Cargo.toml sets panic="abort", so any panic kills the whole process with no
     // diagnostic by default. eprintln! (not tracing) because the subscriber may not be
-    // initialized when the panic fires.
+    // initialized when the panic fires. force_capture() always captures a trace regardless
+    // of RUST_BACKTRACE, so a crash is never left unexplained.
     std::panic::set_hook(Box::new(|info| {
         let location = info
             .location()
@@ -66,7 +74,8 @@ fn main() -> anyhow::Result<()> {
             .map(|s| (*s).to_string())
             .or_else(|| info.payload().downcast_ref::<String>().cloned())
             .unwrap_or_else(|| "<non-string panic payload>".to_string());
-        eprintln!("[PANIC] NEXUS panicked at {location}: {msg}");
+        let backtrace = std::backtrace::Backtrace::force_capture().to_string();
+        eprintln!("{}", format_panic_report(&location, &msg, &backtrace));
     }));
 
     let cli = Cli::parse();
@@ -934,3 +943,24 @@ fn check_status(pid_file: &std::path::Path) -> anyhow::Result<()> {
 #[cfg(test)]
 #[path = "watcher_test.rs"]
 mod watcher_test;
+
+#[cfg(test)]
+mod panic_report_tests {
+    use super::format_panic_report;
+
+    #[test]
+    fn report_includes_location_message_and_backtrace() {
+        let out = format_panic_report("src/foo.rs:10:5", "boom", "0: alpha_frame\n1: beta_frame");
+        assert!(out.contains("src/foo.rs:10:5"), "location missing: {out}");
+        assert!(out.contains("boom"), "message missing: {out}");
+        assert!(out.contains("alpha_frame"), "backtrace missing: {out}");
+        assert!(out.starts_with("[PANIC] NEXUS panicked at"), "prefix missing: {out}");
+    }
+
+    #[test]
+    fn force_capture_backtrace_is_nonempty() {
+        // Proves the crash-diagnostic mechanism is available in this build profile.
+        let bt = std::backtrace::Backtrace::force_capture().to_string();
+        assert!(!bt.is_empty());
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -53,16 +53,29 @@ pub static SHUTDOWN_TOKEN: std::sync::LazyLock<CancellationToken> =
 /// Format the crash diagnostic emitted by the panic hook (Issue #72). Kept as a pure
 /// function so it can be unit-tested — the hook itself cannot be, because Cargo.toml sets
 /// `panic="abort"`, which aborts the test process before any assertion runs.
-fn format_panic_report(location: &str, msg: &str, backtrace: &str) -> String {
-    format!("[PANIC] NEXUS panicked at {location}: {msg}\n[PANIC] backtrace:\n{backtrace}")
+///
+/// `backtrace` is `None` unless a trace was actually captured (see the hook), so the
+/// production binary logs a clean `location: message` line with no empty backtrace block.
+fn format_panic_report(location: &str, msg: &str, backtrace: Option<&str>) -> String {
+    match backtrace {
+        Some(bt) => {
+            format!("[PANIC] NEXUS panicked at {location}: {msg}\n[PANIC] backtrace:\n{bt}")
+        }
+        None => format!("[PANIC] NEXUS panicked at {location}: {msg}"),
+    }
 }
 
 fn main() -> anyhow::Result<()> {
-    // Issue #72/#65: log the panic payload + location + backtrace before the process
-    // aborts. Cargo.toml sets panic="abort", so any panic kills the whole process with no
-    // diagnostic by default. eprintln! (not tracing) because the subscriber may not be
-    // initialized when the panic fires. force_capture() always captures a trace regardless
-    // of RUST_BACKTRACE, so a crash is never left unexplained.
+    // Issue #72/#65: log the panic payload + location (+ backtrace when available) before
+    // the process aborts. Cargo.toml sets panic="abort", so any panic kills the whole
+    // process with no diagnostic by default. eprintln! (not tracing) because the subscriber
+    // may not be initialized when the panic fires.
+    //
+    // The release binary is stripped (Cargo.toml: strip=true) for size, so symbolized
+    // backtrace frames only resolve in a debug build. We therefore use Backtrace::capture()
+    // (which honors RUST_BACKTRACE) and append the backtrace section only when one was
+    // actually captured — the panic location+message (a #[track_caller] literal) stays
+    // useful even in the stripped production binary, with no wall of "<unknown>" frames.
     std::panic::set_hook(Box::new(|info| {
         let location = info
             .location()
@@ -74,8 +87,10 @@ fn main() -> anyhow::Result<()> {
             .map(|s| (*s).to_string())
             .or_else(|| info.payload().downcast_ref::<String>().cloned())
             .unwrap_or_else(|| "<non-string panic payload>".to_string());
-        let backtrace = std::backtrace::Backtrace::force_capture().to_string();
-        eprintln!("{}", format_panic_report(&location, &msg, &backtrace));
+        let backtrace = std::backtrace::Backtrace::capture();
+        let rendered = (backtrace.status() == std::backtrace::BacktraceStatus::Captured)
+            .then(|| backtrace.to_string());
+        eprintln!("{}", format_panic_report(&location, &msg, rendered.as_deref()));
     }));
 
     let cli = Cli::parse();
@@ -949,18 +964,22 @@ mod panic_report_tests {
     use super::format_panic_report;
 
     #[test]
-    fn report_includes_location_message_and_backtrace() {
-        let out = format_panic_report("src/foo.rs:10:5", "boom", "0: alpha_frame\n1: beta_frame");
+    fn report_with_backtrace_appends_section() {
+        let out =
+            format_panic_report("src/foo.rs:10:5", "boom", Some("0: alpha_frame\n1: beta_frame"));
         assert!(out.contains("src/foo.rs:10:5"), "location missing: {out}");
         assert!(out.contains("boom"), "message missing: {out}");
-        assert!(out.contains("alpha_frame"), "backtrace missing: {out}");
+        assert!(out.contains("[PANIC] backtrace:"), "backtrace header missing: {out}");
+        assert!(out.contains("alpha_frame"), "backtrace body missing: {out}");
         assert!(out.starts_with("[PANIC] NEXUS panicked at"), "prefix missing: {out}");
     }
 
     #[test]
-    fn force_capture_backtrace_is_nonempty() {
-        // Proves the crash-diagnostic mechanism is available in this build profile.
-        let bt = std::backtrace::Backtrace::force_capture().to_string();
-        assert!(!bt.is_empty());
+    fn report_without_backtrace_is_single_line() {
+        // Production path (stripped binary, no RUST_BACKTRACE): location + message only,
+        // with no empty "backtrace:" block.
+        let out = format_panic_report("src/foo.rs:10:5", "boom", None);
+        assert_eq!(out, "[PANIC] NEXUS panicked at src/foo.rs:10:5: boom");
+        assert!(!out.contains("backtrace"), "should have no backtrace section: {out}");
     }
 }


### PR DESCRIPTION
## Summary

Completes **#72 (crash-loop protection)** by hardening the panic hook, and closes the issue with a documented rationale for the criteria intentionally not implemented.

`Cargo.toml` sets `panic = "abort"`, so any panic kills the process with no unwind. The hook logs **payload + location**, and appends a **symbolized backtrace when one is available**.

Closes #72.

## ⚠️ Key finding during testing — backtrace vs. stripped binary

The production binary is built with `strip = true` (size optimization — `opt-level=z`, the ~10 MB binary is a project goal). Empirically verified: a `Backtrace::force_capture()` in that stripped binary resolves to a **wall of `<unknown>` frames** — pure noise, because std's symbolizer needs DWARF that `strip` removes. Carrying DWARF (`strip=false` + `debug`) makes traces useful but **inflates the binary substantially** (repro: +530%).

**Resolution (no size regression):** use `Backtrace::capture()` (honors `RUST_BACKTRACE`) and append the backtrace **only when actually captured**:

- **Production** (stripped, no `RUST_BACKTRACE`): a clean `[PANIC] … at file:line:col: message` line. The location works even when stripped because it is a `#[track_caller]` literal, independent of symbols — this is the genuinely useful prod diagnostic.
- **Debug build with `RUST_BACKTRACE=1`**: full symbolized backtrace (names + line numbers).

No `<unknown>` noise, no binary-size change.

## Acceptance criteria — final disposition

| # | Criterion | Status |
|---|-----------|--------|
| 1 | Panic hook logs stack trace | ✅ **This PR** — payload + location always; symbolized backtrace when available (debug / `RUST_BACKTRACE`). Stripped release logs location+message by design |
| 2 | systemd `RestartSec=10` + `StartLimitBurst=5` | ✅ Already in place (`scripts/nexus-ai-gateway.service`) |
| 3 | Enable core dumps | ⛔ **Rejected (security)** — the proxy holds API keys in memory; a core dump would persist secrets to disk in plaintext |
| 4 | In-app crash-loop → safe mode | ⛔ **Redundant** — supervisor-level `StartLimit*` already configured, and the documented root-cause trigger (config hot-reload storm) is already eliminated by the 5-layer reload protection in `main.rs` (debounce + cooldown + mtime + drain + `AtomicBool`) |

## Changes

- `src/main.rs` — `capture()`-gated backtrace in the panic hook; `format_panic_report()` as a pure helper taking `Option<&str>`; 2 unit tests (with/without backtrace)

## Test plan

- [x] `format_panic_report` appends the backtrace section when present; emits a single `location: message` line when absent
- [x] Full suite: **382 tests, 0 failures** · `cargo fmt --check` clean · `cargo clippy -- -D warnings` clean
- [x] **Empirical hook validation** (standalone repro, exact hook logic): stripped/no-`RUST_BACKTRACE` → single clean line, **no `<unknown>` noise**; debug + `RUST_BACKTRACE=1` → symbolized frames with names + line numbers
- [x] **Live regression:** isolated `:8316` instance with the rebuilt binary served a real `claude` request end-to-end (`HOOK_A_OK`, no panic). Production `:8315` untouched; temp secret shredded.

> The hook firing on a real panic cannot be unit-tested (`panic="abort"` aborts the test process), hence the pure-helper test + standalone empirical repro.

🤖 Generated with [Claude Code](https://claude.com/claude-code)