### PR TITLE
fix(proxy): context headroom + reject impossible requests + robust decode (#107, #119)

### DIFF
--- a/src/models/openai.rs
+++ b/src/models/openai.rs
@@ -285,7 +285,11 @@ pub struct OpenAIResponse {
     pub created: u64,
     pub model: String,
     pub choices: Vec<Choice>,
-    pub usage: Usage,
+    // Issue #119: degenerate NIM responses (near-full context) send `"usage":null`.
+    // Optional + default so the body still decodes; the empty-`choices` guard in
+    // resilient_send turns it into a clear ContextOverflow error.
+    #[serde(default)]
+    pub usage: Option<Usage>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub system_fingerprint: Option<String>,
 }

--- a/src/proxy/mod.rs
+++ b/src/proxy/mod.rs
@@ -332,15 +332,17 @@ pub async fn proxy_handler(
     let threshold_pct = get_overflow_threshold_pct();
     match context_precheck(estimated_input, requested_output, context_limit, threshold_pct) {
         PreCheck::Reject { safe_zone } => {
+            // Report the output budget actually left after the input, not the safe-zone total.
+            let remaining_output = safe_zone.saturating_sub(estimated_input);
             tracing::warn!(
-                "[WARN] Pre-check REJECT: ~{}tok input leaves < {}tok usable output (safe zone {} = {}% of {}, model={}). Returning /compact error.",
-                estimated_input, MIN_USEFUL_OUTPUT, safe_zone, threshold_pct, context_limit, openai_req.model
+                "[WARN] Pre-check REJECT: ~{}tok input leaves {}tok < {}tok min output (safe zone {} = {}% of {}, model={}). Returning /compact error.",
+                estimated_input, remaining_output, MIN_USEFUL_OUTPUT, safe_zone, threshold_pct, context_limit, openai_req.model
             );
             return Err(ProxyError::ContextOverflow(format!(
-                "Context window nearly full: ~{} input tokens leave fewer than {} tokens for \
-                 output (model limit {}, usable {}). Use /compact to reduce context, or switch \
-                 to a larger-context model.",
-                estimated_input, MIN_USEFUL_OUTPUT, context_limit, safe_zone
+                "Context window nearly full: ~{} input tokens leave only {} tokens for output \
+                 (fewer than the {} minimum; model limit {}, usable {}). Use /compact to reduce \
+                 context, or switch to a larger-context model.",
+                estimated_input, remaining_output, MIN_USEFUL_OUTPUT, context_limit, safe_zone
             )));
         }
         PreCheck::Clamp { safe_output, safe_zone } => {

--- a/src/proxy/mod.rs
+++ b/src/proxy/mod.rs
@@ -122,6 +122,50 @@ pub(crate) fn get_overflow_threshold_pct() -> u32 {
         .unwrap_or(90)
 }
 
+/// Issue #107/#119: minimum output budget that makes a request worth sending. When the
+/// input leaves less than this inside the safe zone, the request is hopeless and is
+/// rejected early instead of being sent to fail expensively (or return a degenerate
+/// empty 200 that the non-streaming path can't decode).
+pub(crate) const MIN_USEFUL_OUTPUT: u32 = 8192;
+
+/// Outcome of the context pre-check.
+#[derive(Debug, PartialEq, Eq)]
+pub(crate) enum PreCheck {
+    /// Request fits inside the safe zone as-is.
+    Ok,
+    /// Clamp `max_tokens` to this value (leaves headroom below the context limit).
+    Clamp { safe_output: u32, safe_zone: u32 },
+    /// Reject — input alone leaves less than `MIN_USEFUL_OUTPUT` inside the safe zone.
+    Reject { safe_zone: u32 },
+}
+
+/// Decide how to handle a request given its estimated input, requested output, the
+/// upstream context limit, and the overflow threshold percentage (Issue #107/#119).
+///
+/// The safe zone is `context_limit * pct%`. We clamp the output so `input + output` stays
+/// inside it (leaving headroom — NIM returns a degenerate empty 200 when the total reaches
+/// ~98%+ of the limit, verified empirically), and reject outright when the input is so
+/// large that no useful output budget remains.
+pub(crate) fn context_precheck(
+    estimated_input: u32,
+    requested_output: u32,
+    context_limit: u32,
+    threshold_pct: u32,
+) -> PreCheck {
+    let safe_zone = ((context_limit as u64 * threshold_pct as u64) / 100) as u32;
+    if estimated_input.saturating_add(MIN_USEFUL_OUTPUT) > safe_zone {
+        return PreCheck::Reject { safe_zone };
+    }
+    if estimated_input.saturating_add(requested_output) > safe_zone {
+        // max_fit >= MIN_USEFUL_OUTPUT here (otherwise we'd have rejected above), so the
+        // min/max chain never inverts and never panics like `clamp` would.
+        let safe_output =
+            safe_zone.saturating_sub(estimated_input).min(requested_output).max(MIN_USEFUL_OUTPUT);
+        return PreCheck::Clamp { safe_output, safe_zone };
+    }
+    PreCheck::Ok
+}
+
 /// Resolve the raw CC context window without system overhead.
 /// Priority order:
 /// 1. CC_MODEL_CONTEXT_WINDOWS per-model mapping (highest priority)
@@ -282,19 +326,31 @@ pub async fn proxy_handler(
     let estimated_input = tokenizer::estimate_from_openai_request(&openai_req);
     let requested_output = openai_req.max_tokens.unwrap_or(64000);
 
-    if estimated_input + requested_output > context_limit {
-        // Use 256-token safety margin to account for tiktoken vs NIM tokenizer differences
-        let safe_output =
-            context_limit.saturating_sub(estimated_input).saturating_sub(256).clamp(1024, 64000);
-        tracing::warn!(
-            "[WARN] Pre-check: ~{}tok + {}tok > {}tok (model={}, tiktoken). Clamping -> {}",
-            estimated_input,
-            requested_output,
-            context_limit,
-            openai_req.model,
-            safe_output
-        );
-        openai_req.max_tokens = Some(safe_output);
+    // Issue #107/#119: leave headroom inside the context limit and reject hopeless
+    // requests early (a near-full context makes NIM return a degenerate empty 200 that
+    // the non-streaming path can't decode -> opaque 502).
+    let threshold_pct = get_overflow_threshold_pct();
+    match context_precheck(estimated_input, requested_output, context_limit, threshold_pct) {
+        PreCheck::Reject { safe_zone } => {
+            tracing::warn!(
+                "[WARN] Pre-check REJECT: ~{}tok input leaves < {}tok usable output (safe zone {} = {}% of {}, model={}). Returning /compact error.",
+                estimated_input, MIN_USEFUL_OUTPUT, safe_zone, threshold_pct, context_limit, openai_req.model
+            );
+            return Err(ProxyError::ContextOverflow(format!(
+                "Context window nearly full: ~{} input tokens leave fewer than {} tokens for \
+                 output (model limit {}, usable {}). Use /compact to reduce context, or switch \
+                 to a larger-context model.",
+                estimated_input, MIN_USEFUL_OUTPUT, context_limit, safe_zone
+            )));
+        }
+        PreCheck::Clamp { safe_output, safe_zone } => {
+            tracing::warn!(
+                "[WARN] Pre-check: ~{}tok + {}tok > safe zone {} ({}% of {}, model={}). Clamping -> {} (headroom preserved)",
+                estimated_input, requested_output, safe_zone, threshold_pct, context_limit, openai_req.model, safe_output
+            );
+            openai_req.max_tokens = Some(safe_output);
+        }
+        PreCheck::Ok => {}
     }
 
     if config.verbose {
@@ -825,5 +881,64 @@ mod keepalive_interval_tests {
     fn test_keepalive_interval_is_30s() {
         // Verify the constant is accessible and correct
         assert_eq!(KEEPALIVE_INTERVAL_SECS, 30);
+    }
+}
+
+#[cfg(test)]
+mod precheck_tests {
+    use super::{context_precheck, PreCheck, MIN_USEFUL_OUTPUT};
+
+    // glm-5.1 limit; safe_zone @90% = 182476.
+    const LIMIT: u32 = 202752;
+
+    #[test]
+    fn rejects_when_input_leaves_no_useful_output() {
+        // 190000 + 8192 > 182476 -> hopeless (Issue #107).
+        assert_eq!(
+            context_precheck(190_000, 64_000, LIMIT, 90),
+            PreCheck::Reject { safe_zone: 182_476 }
+        );
+    }
+
+    #[test]
+    fn clamps_with_headroom_for_panthera_case() {
+        // The exact failing case: 149379 input + 64000 requested. Clamp to the safe zone,
+        // leaving ~10% headroom (was filling to 99.9% -> degenerate empty 200).
+        assert_eq!(
+            context_precheck(149_379, 64_000, LIMIT, 90),
+            PreCheck::Clamp { safe_output: 33_097, safe_zone: 182_476 }
+        );
+    }
+
+    #[test]
+    fn clamp_caps_at_max_fit_not_requested() {
+        // input 150000 + requested 40000 = 190000 > safe_zone -> clamp to 32476 (max fit).
+        assert_eq!(
+            context_precheck(150_000, 40_000, LIMIT, 90),
+            PreCheck::Clamp { safe_output: 32_476, safe_zone: 182_476 }
+        );
+    }
+
+    #[test]
+    fn ok_when_request_fits_inside_safe_zone() {
+        assert_eq!(context_precheck(10_000, 4_000, LIMIT, 90), PreCheck::Ok);
+    }
+
+    #[test]
+    fn small_requested_below_min_useful_does_not_panic_and_is_ok() {
+        // requested (4000) < MIN_USEFUL_OUTPUT but the total fits -> Ok, no clamp/panic.
+        assert!(4_000 < MIN_USEFUL_OUTPUT);
+        assert_eq!(context_precheck(170_000, 4_000, LIMIT, 90), PreCheck::Ok);
+    }
+
+    #[test]
+    fn degenerate_empty_200_body_decodes_with_optional_usage() {
+        // Issue #119: NIM's near-full-context degenerate 200. Must decode (usage Option)
+        // so the empty-choices guard can turn it into a clear ContextOverflow error.
+        let body = r#"{"id":"","choices":[],"created":0,"model":"","service_tier":null,"system_fingerprint":null,"object":"chat.completion","usage":null}"#;
+        let resp: crate::models::openai::OpenAIResponse =
+            serde_json::from_str(body).expect("degenerate body must decode with Option usage");
+        assert!(resp.choices.is_empty(), "guard relies on empty choices");
+        assert!(resp.usage.is_none(), "usage:null must decode to None");
     }
 }

--- a/src/proxy/retry.rs
+++ b/src/proxy/retry.rs
@@ -141,7 +141,35 @@ pub(crate) async fn resilient_send(
         if status.is_success() {
             circuit_breaker.record_success(generation).await;
             OverflowLoopTracker::reset_tracker(&openai_req.model);
-            let resp: openai::OpenAIResponse = response.json().await?;
+            // Issue #119: read the body first so a degenerate/empty 200 (which NIM returns
+            // when input+max_tokens leave no room) becomes a clear, non-retriable
+            // ContextOverflow (400 -> /compact) instead of an opaque
+            // "502 HTTP error: error decoding response body".
+            let body = response.bytes().await?;
+            let resp: openai::OpenAIResponse = serde_json::from_slice(&body).map_err(|e| {
+                let body_str = String::from_utf8_lossy(&body);
+                let preview = crate::str_utils::safe_truncate(&body_str, 300);
+                tracing::error!(
+                    "[DECODE] non-streaming 200 body undecodable: {e} | body: {preview}"
+                );
+                ProxyError::ContextOverflow(
+                    "Upstream returned an undecodable response (likely empty — the context is \
+                     too full to leave room for output). Use /compact to reduce context."
+                        .to_string(),
+                )
+            })?;
+            if resp.choices.is_empty() {
+                tracing::warn!(
+                    "[DECODE] non-streaming upstream returned empty choices (degenerate 200 — \
+                     context too full for model {})",
+                    openai_req.model
+                );
+                return Err(ProxyError::ContextOverflow(
+                    "Upstream returned an empty response (no choices) — the request left no room \
+                     for output. Use /compact to reduce context."
+                        .to_string(),
+                ));
+            }
             if attempt > 1 {
                 tracing::info!("🔄 Request succeeded on attempt #{}", attempt);
             }

--- a/src/proxy/retry.rs
+++ b/src/proxy/retry.rs
@@ -139,8 +139,6 @@ pub(crate) async fn resilient_send(
         let status = response.status();
 
         if status.is_success() {
-            circuit_breaker.record_success(generation).await;
-            OverflowLoopTracker::reset_tracker(&openai_req.model);
             // Issue #119: read the body first so a degenerate/empty 200 (which NIM returns
             // when input+max_tokens leave no room) becomes a clear, non-retriable
             // ContextOverflow (400 -> /compact) instead of an opaque
@@ -170,6 +168,10 @@ pub(crate) async fn resilient_send(
                         .to_string(),
                 ));
             }
+            // Only a genuinely usable body counts as success (Issue #119): record health and
+            // clear overflow history AFTER validation — never on a degenerate/empty 200.
+            circuit_breaker.record_success(generation).await;
+            OverflowLoopTracker::reset_tracker(&openai_req.model);
             if attempt > 1 {
                 tracing::info!("🔄 Request succeeded on attempt #{}", attempt);
             }

--- a/src/transform.rs
+++ b/src/transform.rs
@@ -527,8 +527,9 @@ pub fn openai_to_anthropic(
         stop_reason,
         stop_sequence: None,
         usage: {
-            let raw_input = resp.usage.prompt_tokens;
-            let raw_output = resp.usage.completion_tokens;
+            // Issue #119: usage is now Option (degenerate NIM 200s omit it). Default to 0.
+            let raw_input = resp.usage.as_ref().map(|u| u.prompt_tokens).unwrap_or(0);
+            let raw_output = resp.usage.as_ref().map(|u| u.completion_tokens).unwrap_or(0);
             if let Some(params) = scaling {
                 let scaled = crate::proxy::token_scaling::scale_token_usage(
                     raw_input,

--- a/src/transform_test.rs
+++ b/src/transform_test.rs
@@ -514,11 +514,11 @@ mod tests {
                 },
                 finish_reason: Some("stop".to_string()),
             }],
-            usage: crate::models::openai::Usage {
+            usage: Some(crate::models::openai::Usage {
                 prompt_tokens: 100,
                 completion_tokens: 50,
                 total_tokens: 150,
-            },
+            }),
         };
 
         // Test with None scaling - should pass through raw tokens
@@ -550,11 +550,11 @@ mod tests {
                 },
                 finish_reason: Some("stop".to_string()),
             }],
-            usage: crate::models::openai::Usage {
+            usage: Some(crate::models::openai::Usage {
                 prompt_tokens: 50000,
                 completion_tokens: 4000,
                 total_tokens: 54000,
-            },
+            }),
         };
 
         // Test with scaling parameters that trigger Branch 1 (context_limit < cc_context_window)
@@ -592,11 +592,11 @@ mod tests {
                 },
                 finish_reason: Some("stop".to_string()),
             }],
-            usage: crate::models::openai::Usage {
+            usage: Some(crate::models::openai::Usage {
                 prompt_tokens: 100000,
                 completion_tokens: 4000,
                 total_tokens: 104000,
-            },
+            }),
         };
 
         // Test with scaling parameters that trigger Branch 2 (context_limit >= cc_context_window)

--- a/src/web_fetch.rs
+++ b/src/web_fetch.rs
@@ -215,21 +215,21 @@ pub async fn execute_fetch(
     // Si es JSON, devolver raw
     if content_type.contains("application/json") {
         let truncated = truncate_content(&body);
-        tracing::info!("[WebFetch] JSON response: {} chars", truncated.len());
+        tracing::info!("[WebFetch] JSON response: {} bytes", truncated.len());
         return Ok(truncated);
     }
 
     // Si es texto plano, devolver raw
     if content_type.contains("text/plain") {
         let truncated = truncate_content(&body);
-        tracing::info!("[WebFetch] Plain text: {} chars", truncated.len());
+        tracing::info!("[WebFetch] Plain text: {} bytes", truncated.len());
         return Ok(truncated);
     }
 
     // Si es HTML, strip tags
     let text = strip_html_tags(&body);
     let truncated = truncate_content(&text);
-    tracing::info!("[WebFetch] HTML->text: {} -> {} chars", body.len(), truncated.len());
+    tracing::info!("[WebFetch] HTML->text: {} -> {} bytes", body.len(), truncated.len());
     Ok(truncated)
 }
 


### PR DESCRIPTION
## Summary

Fixes the production failure where large-context **non-streaming** requests to NIM (`opus-4-6` → `glm-5.1`) returned an opaque **`502 error decoding response body`** and the auto-compact **death spiral** (#107). Reproduced from a real `Panthera Marketing Group` session.

Closes #107.
Closes #119.

## Root cause (reproduced empirically)

1. Pre-check clamped `max_tokens` to **fill** the context (only a 256-token margin).
2. With ~99% of the context used, NIM returned a degenerate `200 OK`: `{"choices":[],"usage":null}` (no room for output).
3. `OpenAIResponse.usage` was a **required** `Usage`, so `usage:null` failed to decode → `ProxyError::Http` → **502**.
4. CC retried 5×, identical clamp → identical empty body → identical 502.

Headroom sweep (fixed ~157K input): 87% total → OK, 93% → OK, **99% → empty**. The trigger is filling the context, not input size alone.

## Fix

**Pre-check (#107)** — `src/proxy/mod.rs`, new pure `context_precheck()`:
- Safe zone = `context_limit × overflow_threshold%` (default 90%) → leaves ~10% headroom.
- `input + MIN_USEFUL_OUTPUT (8192) > safe_zone` → **reject early** with a clear, non-retriable `ContextOverflow` (400 → `/compact`) instead of a futile clamp-and-retry spiral.
- Otherwise clamp `max_tokens` inside the safe zone (capped at what the client requested).

> Note: uses `ContextOverflow` (400) rather than 413 as the issue suggested — the codebase already established 400 as "non-retriable → immediate /compact feedback", and it is Anthropic-shaped. Consistent and lower-risk.

**Decode (#119)** — `src/models/openai.rs`, `src/proxy/retry.rs`:
- `OpenAIResponse.usage` → `Option<Usage>` (parity with the streaming struct).
- Non-streaming path reads the body first; an undecodable body **or** empty `choices` returns the same clear `ContextOverflow` error (+ truncated body log) instead of an opaque 502.

**Cosmetic** — `src/web_fetch.rs`: byte counts mislabeled `chars` → `bytes`.

## Test plan

- [x] **Unit (6 new):** `context_precheck` reject / clamp-with-headroom (the exact 149K case) / clamp caps at max-fit / fits-as-is / small-request-no-panic; degenerate `{"choices":[],"usage":null}` decodes with `Option` usage.
- [x] Full suite: **393 tests, 0 failures** · `fmt` · `clippy -D warnings` · `cargo audit` all clean.
- [x] **Live `:8316` (the failing scenarios):**
  - ~153K input non-streaming → **clamp to 26987, 200 OK** (was 502).
  - ~181K input → **400** `"Context window nearly full… Use /compact"` (was death spiral).
  - normal sonnet/haiku/math requests → 200 OK, unaffected.
- [x] Production `:8315` untouched; temp secrets shredded.

## Out of scope (found during testing, filed separately)

Intensive `claude` testing surfaced that `claude --model opus` sends **`claude-opus-4-8`**, which is **not in the model map** → raw upstream 404. That is **#105** (unmapped CC 2.1.x model IDs), a config + not-found-shaping concern distinct from this overflow fix — documented for separate handling. Not a regression (0 panics / 0 decode-502 in the test log).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of responses with missing or empty usage data, preventing failures when the upstream service returns incomplete results.
  * Added earlier context-size checks to avoid sending requests that are likely to overflow, with clearer errors and safer output limits.
  * Better handling of malformed or degenerate successful responses, returning a more helpful overflow message instead of a generic parsing failure.
  * Refined logging around truncated web content to report sizes more consistently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->