### PR TITLE
fix(transform): family fallback for unmapped Claude model ids (#105)

### DIFF
--- a/src/transform.rs
+++ b/src/transform.rs
@@ -30,9 +30,15 @@ pub struct TransformResult {
 }
 
 /// Resolve model name and upstream from model map or config defaults
-/// Tier (opus/sonnet/haiku) of a Claude model id (Issue #105).
+/// Tier (opus/sonnet/haiku) of a Claude model id (Issue #105). Constrained to real
+/// `claude-…-<tier>-…` ids (delimited, lowercased) so a non-Claude model that merely
+/// contains a tier word is never rerouted by the family fallback.
 fn model_tier(model: &str) -> Option<&'static str> {
-    ["opus", "sonnet", "haiku"].into_iter().find(|t| model.contains(t))
+    let m = model.to_ascii_lowercase();
+    if !m.starts_with("claude-") {
+        return None;
+    }
+    ["opus", "sonnet", "haiku"].into_iter().find(|t| m.contains(&format!("-{t}-")))
 }
 
 /// Length of the shared leading byte run between two ids.

--- a/src/transform.rs
+++ b/src/transform.rs
@@ -30,6 +30,32 @@ pub struct TransformResult {
 }
 
 /// Resolve model name and upstream from model map or config defaults
+/// Tier (opus/sonnet/haiku) of a Claude model id (Issue #105).
+fn model_tier(model: &str) -> Option<&'static str> {
+    ["opus", "sonnet", "haiku"].into_iter().find(|t| model.contains(t))
+}
+
+/// Length of the shared leading byte run between two ids.
+fn common_prefix_len(a: &str, b: &str) -> usize {
+    a.bytes().zip(b.bytes()).take_while(|(x, y)| x == y).count()
+}
+
+/// Issue #105: find the configured map entry that best covers an unmapped Claude id of the
+/// same family. Newer CC builds ship ids (`claude-opus-4-8`, `claude-sonnet-4-5`, ...) the
+/// map does not list yet; routing them to the closest same-tier mapping keeps opus/sonnet/
+/// haiku usable across CC upgrades without a config change. Picks the same-tier key with the
+/// longest shared prefix, breaking ties by the lexicographically largest key (a newer dotted
+/// version sorts above an older dated snapshot, e.g. `claude-opus-4-6` > `claude-opus-4-20250115`).
+fn best_family_match<'a>(
+    req_model: &str,
+    map: &'a std::collections::HashMap<String, crate::config::ModelRoute>,
+) -> Option<(&'a String, &'a crate::config::ModelRoute)> {
+    let tier = model_tier(req_model)?;
+    map.iter()
+        .filter(|(k, _)| model_tier(k) == Some(tier))
+        .max_by_key(|(k, _)| (common_prefix_len(req_model, k), (*k).clone()))
+}
+
 pub(crate) fn resolve_model_and_upstream(
     req_model: &str,
     has_thinking: bool,
@@ -45,7 +71,20 @@ pub(crate) fn resolve_model_and_upstream(
         );
         return (route.target_model.clone(), route.upstream_name.clone());
     }
-    // 2. Fallback to configured model overrides
+    // 2. Issue #105: family fallback for newer CC model ids the map does not list yet
+    // (e.g. claude-opus-4-8 -> the configured claude-opus-4-6 route). Without this an
+    // unmapped id is forwarded verbatim and NVIDIA returns a raw "404 page not found".
+    if let Some((matched, route)) = best_family_match(req_model, &config.model_map) {
+        tracing::warn!(
+            "[PIN] Model family fallback: {} -> {}:{} (no exact map; matched '{}' by family)",
+            req_model,
+            route.upstream_name,
+            route.target_model,
+            matched
+        );
+        return (route.target_model.clone(), route.upstream_name.clone());
+    }
+    // 3. Fallback to configured model overrides
     let model =
         if has_thinking { config.reasoning_model.clone() } else { config.completion_model.clone() }
             .unwrap_or_else(|| req_model.to_string());

--- a/src/transform_test.rs
+++ b/src/transform_test.rs
@@ -764,4 +764,76 @@ mod tests {
             "chat_template_kwargs should NOT be present when upstream is Anthropic even if global is NIM"
         );
     }
+
+    // ── Issue #105: model family fallback for unmapped newer CC ids ──
+    fn family_map() -> HashMap<String, ModelRoute> {
+        let mut m = HashMap::new();
+        m.insert(
+            "claude-opus-4-5".to_string(),
+            ModelRoute { upstream_name: "default".into(), target_model: "old/opus".into() },
+        );
+        m.insert(
+            "claude-opus-4-6".to_string(),
+            ModelRoute { upstream_name: "default".into(), target_model: "z-ai/glm-5.1".into() },
+        );
+        m.insert(
+            "claude-sonnet-4-6".to_string(),
+            ModelRoute {
+                upstream_name: "default".into(),
+                target_model: "moonshotai/kimi-k2.6".into(),
+            },
+        );
+        m
+    }
+
+    #[test]
+    fn model_tier_detects_known_families() {
+        use crate::transform::model_tier;
+        assert_eq!(model_tier("claude-opus-4-8"), Some("opus"));
+        assert_eq!(model_tier("claude-sonnet-4-5"), Some("sonnet"));
+        assert_eq!(model_tier("claude-haiku-4-5"), Some("haiku"));
+        assert_eq!(model_tier("gpt-4o"), None);
+    }
+
+    #[test]
+    fn family_fallback_routes_unmapped_opus_to_newest_configured_opus() {
+        use crate::transform::best_family_match;
+        let map = family_map();
+        let (matched, route) =
+            best_family_match("claude-opus-4-8", &map).expect("opus family must match");
+        assert_eq!(matched, "claude-opus-4-6", "should prefer the lexically-newest opus");
+        assert_eq!(route.target_model, "z-ai/glm-5.1");
+    }
+
+    #[test]
+    fn family_fallback_routes_unmapped_sonnet_to_configured_sonnet() {
+        use crate::transform::best_family_match;
+        let map = family_map();
+        let (matched, route) =
+            best_family_match("claude-sonnet-4-5", &map).expect("sonnet family must match");
+        assert_eq!(matched, "claude-sonnet-4-6");
+        assert_eq!(route.target_model, "moonshotai/kimi-k2.6");
+    }
+
+    #[test]
+    fn family_fallback_none_for_unknown_tier() {
+        use crate::transform::best_family_match;
+        assert!(best_family_match("gpt-4o", &family_map()).is_none());
+    }
+
+    #[test]
+    fn family_fallback_prefers_clean_version_over_dated_snapshot() {
+        use crate::transform::best_family_match;
+        let mut map = HashMap::new();
+        map.insert(
+            "claude-opus-4-20250115".to_string(),
+            ModelRoute { upstream_name: "default".into(), target_model: "dated/opus".into() },
+        );
+        map.insert(
+            "claude-opus-4-6".to_string(),
+            ModelRoute { upstream_name: "default".into(), target_model: "z-ai/glm-5.1".into() },
+        );
+        let (matched, _) = best_family_match("claude-opus-4-8", &map).unwrap();
+        assert_eq!(matched, "claude-opus-4-6", "clean dotted version sorts above dated snapshot");
+    }
 }

--- a/src/transform_test.rs
+++ b/src/transform_test.rs
@@ -792,7 +792,11 @@ mod tests {
         assert_eq!(model_tier("claude-opus-4-8"), Some("opus"));
         assert_eq!(model_tier("claude-sonnet-4-5"), Some("sonnet"));
         assert_eq!(model_tier("claude-haiku-4-5"), Some("haiku"));
+        assert_eq!(model_tier("claude-3-opus-20240229"), Some("opus"));
+        // Constrained to real claude ids (Issue #105 / CodeRabbit): no false positives.
         assert_eq!(model_tier("gpt-4o"), None);
+        assert_eq!(model_tier("some-sonnet-engine"), None, "non-claude id must not reroute");
+        assert_eq!(model_tier("CLAUDE-OPUS-4-8"), Some("opus"), "case-insensitive");
     }
 
     #[test]


### PR DESCRIPTION
## Summary

`claude --model opus` was **unusable** through the gateway: CC 2.1.x sends `claude-opus-4-8`, which the model map does not list, so it was forwarded verbatim and NVIDIA returned a raw `404 page not found`.

Closes #105.

## Fix

`resolve_model_and_upstream()` gains a **family-fallback** step between the exact-map lookup and the generic fallback: an unmapped id is routed to the configured map entry of the **same tier** (opus/sonnet/haiku) with the longest shared prefix, breaking ties by the lexically-newest key.

- `claude-opus-4-8` → the configured `claude-opus-4-6` route (e.g. `z-ai/glm-5.1`).
- Robust across CC upgrades (`opus-4-9`, …) with **no config change**.
- A clean dotted version (`claude-opus-4-6`) sorts above a dated snapshot (`claude-opus-4-20250115`).
- **Exact map hits are unchanged** (step 1 still wins).

## Test plan

- [x] **Unit (5):** `model_tier` detection; unmapped opus → newest configured opus; unmapped sonnet → configured sonnet; unknown tier → no match; clean version preferred over dated snapshot.
- [x] Full suite: **398 tests, 0 failures** · `fmt` · `clippy -D warnings` · unicode clean.
- [x] **Live `:8316`** (map intentionally omits `opus-4-8`): `claude --model opus` (sends `claude-opus-4-8`) → **`OPUS105_OK`**, routed via `Model family fallback: claude-opus-4-8 -> default:z-ai/glm-5.1 (matched 'claude-opus-4-6')` (was 404). `sonnet`/`haiku` exact-map routing unaffected. Production `:8315` untouched; temp secret shredded.

## Notes

- Optional follow-up (#105 part 2b, not included): Anthropic-shaped `not_found_error` for a model that matches no tier at all. The family fallback already covers all opus/sonnet/haiku cases, so this is now a rare edge.
- Config maps for the new ids can still be added to `.env` for explicit control, but are no longer required for opus/sonnet/haiku to work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved model routing so newer Claude model IDs can automatically fall back to the best matching model family when an exact match isn’t available.
  * Added smarter selection across compatible model versions, including preference for the most appropriate current version over older snapshots.

* **Bug Fixes**
  * Reduced routing failures for unmapped model IDs by using a family-based fallback before defaulting to the configured model.
  * Added clearer warning logs when a fallback match is used.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->