### PR TITLE
fix(discovery): model-limit hardening — skip dead NIM probe, reject implausible overrides, byte labels (#104, #106 §8)

### DIFF
--- a/src/proxy/discovery.rs
+++ b/src/proxy/discovery.rs
@@ -187,6 +187,21 @@ pub async fn get_context_limit(
         }
     }
 
+    // Issue #104: NVIDIA NIM silently clamps an oversized max_tokens (HTTP 200, no
+    // `max_total_tokens=` error string), so the error-parsing probe never succeeds — it only
+    // burns a round-trip + PROBE_TIMEOUT and re-warns on every request (there is no negative
+    // cache). Skip it for NIM and use the fallback; pin real limits via MODEL_LIMIT_OVERRIDES.
+    // Non-NIM upstreams still probe.
+    if config.get_upstream_type(upstream_name) == crate::config::UpstreamType::NIM {
+        let fallback = default_context_limit();
+        tracing::debug!(
+            "[SCAN] NIM probe skipped for '{}' (silent clamp, Issue #104) — using fallback {}. Pin via MODEL_LIMIT_OVERRIDES.",
+            model,
+            fallback
+        );
+        return fallback;
+    }
+
     // 2. Get upstream base URL (without /v1/chat/completions)
     let upstream = config.upstreams.get(upstream_name).or_else(|| config.upstreams.get("default"));
 

--- a/src/proxy/discovery.rs
+++ b/src/proxy/discovery.rs
@@ -76,21 +76,48 @@ fn probing_disabled() -> bool {
         .unwrap_or(false)
 }
 
-/// Get model limit override from MODEL_LIMIT_OVERRIDES env var
-/// Format: "model-id1:limit1,model-id2:limit2"
-fn get_model_limit_override(model_id: &str) -> Option<u32> {
-    std::env::var("MODEL_LIMIT_OVERRIDES").ok().and_then(|overrides| {
-        overrides.split(',').find_map(|entry| {
-            let mut parts = entry.trim().split(':');
-            let model = parts.next()?;
-            let limit: u32 = parts.next()?.trim().parse().ok()?;
-            if model == model_id {
-                Some(limit)
-            } else {
+/// A context limit below this is almost certainly a parse error (Issue #106 §8): e.g. a
+/// comma thousands-separator in `…:1,048,576` splits on `,` into `…:1` -> limit 1. Reject
+/// such values rather than silently capping a model at a useless context.
+const MIN_PLAUSIBLE_LIMIT: u32 = 1024;
+
+/// Pure parser for `MODEL_LIMIT_OVERRIDES` (`model-id1:limit1,model-id2:limit2`). Returns
+/// the override for `model_id`, ignoring implausibly small / non-numeric limits with a
+/// warning so a malformed entry never silently wins.
+fn parse_limit_override(overrides: &str, model_id: &str) -> Option<u32> {
+    overrides.split(',').find_map(|entry| {
+        let mut parts = entry.trim().split(':');
+        let model = parts.next()?;
+        if model != model_id {
+            return None;
+        }
+        let raw = parts.next()?.trim();
+        match raw.parse::<u32>() {
+            Ok(limit) if limit >= MIN_PLAUSIBLE_LIMIT => Some(limit),
+            Ok(limit) => {
+                tracing::warn!(
+                    "MODEL_LIMIT_OVERRIDES: ignoring implausibly small limit {} for '{}' (min {}). \
+                     Check for comma thousands-separators — use 1048576, not 1,048,576.",
+                    limit, model_id, MIN_PLAUSIBLE_LIMIT
+                );
                 None
             }
-        })
+            Err(e) => {
+                tracing::warn!(
+                    "MODEL_LIMIT_OVERRIDES: invalid limit '{}' for '{}' ({}) — ignoring.",
+                    raw,
+                    model_id,
+                    e
+                );
+                None
+            }
+        }
     })
+}
+
+/// Get model limit override from the `MODEL_LIMIT_OVERRIDES` env var.
+fn get_model_limit_override(model_id: &str) -> Option<u32> {
+    std::env::var("MODEL_LIMIT_OVERRIDES").ok().and_then(|o| parse_limit_override(&o, model_id))
 }
 
 /// Probe NIM to discover a model's max_total_tokens.
@@ -223,5 +250,38 @@ mod fallback_tests {
         // Invalid values fall back to the default.
         assert_eq!(with_env(Some("0"), default_context_limit), 200_000);
         assert_eq!(with_env(Some("garbage"), default_context_limit), 200_000);
+    }
+}
+
+#[cfg(test)]
+mod limit_override_tests {
+    use super::parse_limit_override;
+
+    #[test]
+    fn valid_override_and_model_selection() {
+        let s = "z-ai/glm-5.1:202752,moonshotai/kimi-k2.6:262144";
+        assert_eq!(parse_limit_override(s, "z-ai/glm-5.1"), Some(202752));
+        assert_eq!(parse_limit_override(s, "moonshotai/kimi-k2.6"), Some(262144));
+        assert_eq!(parse_limit_override(s, "other/model"), None);
+    }
+
+    #[test]
+    fn rejects_comma_thousands_separator_artifact() {
+        // Issue #106 §8: "deepseek-ai/deepseek-v4-pro:1,048,576" splits on ',' so the
+        // matching entry becomes "…:1" (limit 1) — must be rejected, never silently cap
+        // the model at 1 token. Surrounding good entries stay unaffected.
+        let s =
+            "z-ai/glm-5.1:202752,deepseek-ai/deepseek-v4-pro:1,048,576,moonshotai/kimi-k2.6:262144";
+        assert_eq!(parse_limit_override(s, "deepseek-ai/deepseek-v4-pro"), None);
+        assert_eq!(parse_limit_override(s, "z-ai/glm-5.1"), Some(202752));
+        assert_eq!(parse_limit_override(s, "moonshotai/kimi-k2.6"), Some(262144));
+    }
+
+    #[test]
+    fn rejects_zero_and_nonnumeric() {
+        assert_eq!(parse_limit_override("m:0", "m"), None);
+        assert_eq!(parse_limit_override("m:abc", "m"), None);
+        assert_eq!(parse_limit_override("m:1023", "m"), None, "below MIN_PLAUSIBLE_LIMIT");
+        assert_eq!(parse_limit_override("m:1024", "m"), Some(1024), "exactly MIN is allowed");
     }
 }

--- a/src/proxy/streaming.rs
+++ b/src/proxy/streaming.rs
@@ -319,7 +319,7 @@ pub(crate) fn create_sse_stream(
                                                 .await
                                                 .unwrap_or_else(|e| format!("Error fetching {}: {}", fetch_url, e))
                                         };
-                                        tracing::info!("[WebFetch/Stream] Fetched {} chars (flushed at [DONE])", fetch_result.len());
+                                        tracing::info!("[WebFetch/Stream] Fetched {} bytes (flushed at [DONE])", fetch_result.len());
                                         if current_block_type.is_some() {
                                             let ev = json!({"type": "content_block_stop", "index": content_index});
                                             yield Ok(Bytes::from(format!("event: content_block_stop\ndata: {}\n\n", serde_json::to_string(&ev).unwrap_or_default())));
@@ -751,7 +751,7 @@ pub(crate) fn create_sse_stream(
                                                         .unwrap_or_else(|e| format!("Error fetching {}: {}", fetch_url, e))
                                                 };
 
-                                                tracing::info!("[WebFetch/Stream] Fetched {} chars", fetch_result.len());
+                                                tracing::info!("[WebFetch/Stream] Fetched {} bytes", fetch_result.len());
 
                                                 if suppressed_block_start {
                                                     // FIX C11 (Issue #80): Close any prior tool_use block that might be


### PR DESCRIPTION
## Summary

Model-limit / discovery hardening — three related fixes surfaced during the #104/#106 investigations.

### 1. Skip the dead NIM context-limit probe (#104)

`probe_model_limit` **never succeeds for NVIDIA NIM**: NIM silently clamps an oversized `max_tokens` (HTTP 200, no `max_total_tokens=` error), so the regex never matches. The probe only burns a round-trip + `PROBE_TIMEOUT` and emits a `Could not probe model` WARN on **every** request (no negative cache).

**Fix:** skip the probe for NIM upstreams and use the fallback (`200000`, ≥ CC's window); pin genuine limits via `MODEL_LIMIT_OVERRIDES`. Non-NIM upstreams still probe. (NVIDIA `/v1/models` exposes no context-length field — verified — so metadata discovery isn't an option.)

### 2. Reject implausible `MODEL_LIMIT_OVERRIDES` limits (#106 §8)

A comma thousands-separator (`deepseek-ai/deepseek-v4-pro:1,048,576`) splits on `,`, so the matching entry becomes `…:1` → a silent **1-token** cap. New pure `parse_limit_override()` ignores limits below a plausible floor (`1024`) and non-numeric/zero limits with a warning, so a malformed entry never silently wins.

### 3. WebFetch byte labels

Two `[WebFetch/Stream] Fetched {} chars` logs reported `.len()` (bytes) as "chars" → `bytes`.

## Test plan

- [x] **Unit (3):** override parsing — valid + model selection; comma-thousands artifact → `None` (was `1`); zero/non-numeric/below-floor rejected, exactly-`1024` allowed.
- [x] Full suite: **405 tests, 0 failures** · `fmt` · `clippy -D warnings` · unicode clean.
- [x] **Live `:8316`:** a NIM request now logs `NIM probe skipped` at debug with **no** `Could not probe` WARN; sonnet/opus turns complete on the fallback (no regression, 0 panics).

Closes #104.
Closes #106 §8 (parser hardening; the `MODEL_LIMIT_OVERRIDES` value should also drop the commas in the operator `.env`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved model limit override handling to avoid accidentally applying implausibly small limits from malformed values.
  * Fixed context-limit behavior for certain upstreams so fallback limits are used consistently instead of probing.
  * Updated fetch result logging to report payload size in bytes for clearer diagnostics.
* **Tests**
  * Added coverage for model limit override parsing, including invalid and edge-case inputs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->