### PR TITLE
ci(security): enforce cargo-deny — wire deny.toml into CI + pre-push (#125)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,12 @@ jobs:
           tool: cargo-audit
       - name: Run security audit
         run: cargo audit
+      - name: Install cargo-deny
+        uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-deny
+      - name: Run cargo-deny (advisories, bans, licenses, sources)
+        run: cargo deny check
 
   test:
     runs-on: ubuntu-latest

--- a/deny.toml
+++ b/deny.toml
@@ -1,10 +1,9 @@
 [advisories]
 db-urls = ["https://github.com/RustSec/advisory-db"]
-ignore = [
-    "RUSTSEC-2025-0069", # daemonize — unmaintained, no alternative
-    "RUSTSEC-2024-0384", # instant — unmaintained, transitive via notify
-    "RUSTSEC-2025-0119", # number_prefix — unmaintained, transitive via indicatif
-]
+# No active ignores. The previous RUSTSEC ignores (daemonize / instant /
+# number_prefix) are no longer in the dependency tree. Re-add an entry here only
+# if an advisory genuinely matches a crate we cannot upgrade.
+ignore = []
 unmaintained = "none"
 
 [bans]

--- a/scripts/hooks/pre-push
+++ b/scripts/hooks/pre-push
@@ -71,6 +71,17 @@ if [ "$remote_ref" = "refs/heads/main" ]; then
 		fi
 	fi
 
+	# 6. Supply-chain / license policy (deny.toml) — non-blocking if cargo-deny not installed
+	if command -v cargo-deny >/dev/null 2>&1; then
+		echo " Running cargo deny check..."
+		if ! cargo deny check 2>/dev/null; then
+			echo "⚠️ cargo-deny policy violations found! Review with: cargo deny check"
+			echo "   (Not blocking push — fix when possible)"
+		else
+			echo " ✅ cargo-deny passed"
+		fi
+	fi
+
 	echo ""
 	echo "✅ Pre-push validation passed"
 


### PR DESCRIPTION
## Summary

Closes #125. `deny.toml` shipped complete supply-chain / license rules (advisories, bans, licenses, sources) but **was never executed** by any automation — dead configuration providing zero protection.

## Changes

- **CI**: add `cargo deny check` to the `security-scan` job (alongside the existing `cargo audit`), installed via `taiki-e/install-action`.
- **pre-push hook**: add `cargo deny check` after the `cargo audit` step — non-blocking, mirroring the existing audit behavior.
- **deny.toml**: remove 3 stale advisory ignores (`daemonize` / `instant` / `number_prefix`) that no longer match any crate in the dependency tree (they produced `advisory-not-detected` warnings).

## Test plan

- [x] `cargo deny check` → **advisories ok, bans ok, licenses ok, sources ok** (exit 0), no warnings after the stale-ignore cleanup.
- [x] `.github/workflows/ci.yml` + valid YAML; mirrors the cargo-audit step pattern.
- [x] `scripts/hooks/pre-push` + `bash -n` syntax OK.
- [x] No Rust changed — runtime binary unaffected (this is CI/tooling only, no version bump).

## Deferred (separate, pre-existing)

The 4th wiring target (`Taskfile.yaml`) is **deferred**: go-task 3.51.1 cannot parse the current Taskfile due to a pre-existing unquoted `':'` in the `version` task (`echo "Cargo.toml: $(...)"` and similar), unrelated to cargo-deny. Bundling that quoting refactor here would violate surgical scope — it will be fixed in its own change, after which a `task deny` + `task check` entry can be added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added broader security policy checks to CI and local pre-push validation.
  * Pre-push checks now optionally run an additional non-blocking scan when the required tool is available.

* **Bug Fixes**
  * Removed outdated security advisory exceptions so current checks reflect the latest policy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->