### PR TITLE
fix(transform): forward CC structured-output schema as response_format (#126)

### DIFF
--- a/src/models/openai.rs
+++ b/src/models/openai.rs
@@ -26,6 +26,10 @@ pub struct OpenAIRequest {
     /// NIM/vLLM chat template kwargs for model-specific features (e.g. GLM5 thinking)
     #[serde(skip_serializing_if = "Option::is_none")]
     pub chat_template_kwargs: Option<Value>,
+    /// Structured-output constraint (OpenAI `response_format`). Translated from CC's
+    /// `output_config.format` (json_schema) so NIM/OpenAI upstreams honor the schema.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub response_format: Option<Value>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/src/tokenizer_test.rs
+++ b/src/tokenizer_test.rs
@@ -169,6 +169,7 @@ fn typed_variant_matches_json_variant() {
         tools: None,
         tool_choice: None,
         chat_template_kwargs: None,
+        response_format: None,
     };
 
     let json_req = serde_json::to_value(&openai_req).unwrap();

--- a/src/transform.rs
+++ b/src/transform.rs
@@ -101,6 +101,24 @@ pub(crate) fn resolve_model_and_upstream(
 
 /// Transform Anthropic request to OpenAI format
 /// Returns (OpenAIRequest, upstream_name) for routing
+/// Translate CC's `output_config.format` (Anthropic structured-output, json_schema)
+/// into an OpenAI `response_format` so NIM / OpenAI-compatible upstreams enforce the
+/// schema. CC sends `{ "type": "json_schema", "schema": {...} }`; OpenAI expects
+/// `{ "type": "json_schema", "json_schema": { "name", "schema", "strict" } }`.
+/// Returns None when the request carries no json_schema format.
+fn structured_output_to_response_format(extra: &serde_json::Value) -> Option<serde_json::Value> {
+    let format = extra.get("output_config")?.get("format")?;
+    if format.get("type")?.as_str()? != "json_schema" {
+        return None;
+    }
+    let schema = format.get("schema")?;
+    let name = format.get("name").and_then(|n| n.as_str()).unwrap_or("structured_output");
+    Some(json!({
+        "type": "json_schema",
+        "json_schema": { "name": name, "schema": schema, "strict": true }
+    }))
+}
+
 pub fn anthropic_to_openai(
     req: anthropic::AnthropicRequest,
     config: &Config,
@@ -298,6 +316,10 @@ pub fn anthropic_to_openai(
             // Issue #35 Bug E / #90-B: chat_template_kwargs is only valid for NIM
             // upstreams; the activation policy (ARB Eje A) resolves it NIM-only.
             chat_template_kwargs: activation.chat_template_kwargs.clone(),
+            // #126: forward CC's structured-output schema (output_config.format) as an
+            // OpenAI response_format so NIM upstreams enforce it instead of returning
+            // free-form prose (which made CC's headless verdict fail with "Execution error").
+            response_format: structured_output_to_response_format(&req.extra),
         },
         upstream_name: upstream_name.to_string(),
         cache_markers,

--- a/src/transform_test.rs
+++ b/src/transform_test.rs
@@ -126,6 +126,75 @@ mod tests {
     }
 
     #[test]
+    fn test_structured_output_translated_to_response_format() {
+        // #126: CC headless mode sends output_config.format (json_schema). NEXUS must
+        // translate it to an OpenAI response_format so NIM enforces the schema instead
+        // of returning free-form prose (which made CC's verdict fail with "Execution error").
+        let schema = json!({
+            "type": "object",
+            "properties": {
+                "ok": {"type": "boolean"},
+                "reason": {"type": "string"}
+            },
+            "required": ["ok", "reason"],
+            "additionalProperties": false
+        });
+        let req = AnthropicRequest {
+            model: "claude-sonnet-4-6".to_string(),
+            messages: vec![],
+            max_tokens: 4096,
+            temperature: None,
+            top_p: None,
+            top_k: None,
+            stop_sequences: None,
+            stream: None,
+            tools: None,
+            system: None,
+            metadata: None,
+            extra: json!({
+                "output_config": { "format": {"type": "json_schema", "schema": schema} }
+            }),
+        };
+        let config = test_config();
+        let result =
+            anthropic_to_openai(req, &config, "default").expect("Transform should succeed");
+
+        let rf = result
+            .request
+            .response_format
+            .expect("response_format must be set when output_config.format is json_schema");
+        assert_eq!(rf["type"], "json_schema");
+        assert_eq!(rf["json_schema"]["name"], "structured_output");
+        assert_eq!(rf["json_schema"]["strict"], true);
+        assert_eq!(rf["json_schema"]["schema"]["required"][0], "ok");
+    }
+
+    #[test]
+    fn test_no_structured_output_leaves_response_format_none() {
+        let req = AnthropicRequest {
+            model: "claude-sonnet-4-6".to_string(),
+            messages: vec![],
+            max_tokens: 4096,
+            temperature: None,
+            top_p: None,
+            top_k: None,
+            stop_sequences: None,
+            stream: None,
+            tools: None,
+            system: None,
+            metadata: None,
+            extra: json!({}),
+        };
+        let config = test_config();
+        let result =
+            anthropic_to_openai(req, &config, "default").expect("Transform should succeed");
+        assert!(
+            result.request.response_format.is_none(),
+            "response_format must be None when no output_config.format is present"
+        );
+    }
+
+    #[test]
     fn test_cache_marker_from_content_block() {
         // Build an AnthropicRequest with a message containing ContentBlock::Text
         // with cache_control


### PR DESCRIPTION
## Summary

Closes #126. CC headless mode (`claude -p`) issues a verdict request with **structured output** (`output_config.format`, `json_schema`, beta `structured-outputs-2025-12-15`) to decide whether a task succeeded. NEXUS **dropped `output_config.format` entirely**, so the NIM model received no schema constraint, returned free-form prose, and CC failed to parse the `{ok, reason}` verdict → **"Execution error"**.

## Fix

Translate CC's `output_config.format` (json_schema) into an OpenAI `response_format`:

```
CC:     { "type": "json_schema", "schema": {...} }            (Anthropic, in output_config.format)
NEXUS:  { "type": "json_schema", "json_schema": { "name", "schema", "strict": true } }   (OpenAI response_format)
```

Applied on the OpenAI-compatible transform path; `None` when the request carries no json_schema format (web_fetch/normal turns are untouched).

## Empirical evidence (controlled tests against kimi-k2.6)

| Mechanism | Result |
|-----------|--------|
| `response_format.json_schema` | ✅ valid JSON: `{"ok": true, "reason": "Rayleigh scattering..."}` |
| `nvext.guided_json` | ❌ garbage prose (`Yes\nvalue: Yes`) |
| `response_format` + forced `enable_thinking` | ✅ still valid JSON |

NVIDIA docs suggest `nvext.guided_json` for vLLM NIM, but kimi-k2.6 empirically honors **`response_format`** and ignores `nvext` — so `response_format` is the correct mechanism here.

## Test plan

- [x] `cargo test` — **401 green** (+2 new: translation present / absent).
- [x] `cargo fmt --check`, `cargo clippy -- -D warnings` — clean.
- [x] **Direct NEXUS streaming** (POST :8316 with `output_config.format`): returns valid `{"ok":...,"reason":...}` as `text_delta` + `stop_reason=end_turn`.
- [x] **Headless `claude -p` end-to-end**: a simple query now completes cleanly (`"2 + 2 equals 4."`, exit 0) — previously every headless query hit the verdict failure.
- [ ] Post-merge re-test on the released build.

## Separate finding (not this PR)

The headless **web_fetch** flow still shows "Execution error" even with this fix. That is a distinct web_fetch+headless interaction (this fix does not touch the web_fetch turn — its `output_config` has no `format`). Interactive web_fetch works (B3, #124). Tracked separately if it warrants its own issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)