### PR TITLE
fix(retry): add first-byte timeout to bound stalled upstreams (#83)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -174,6 +174,7 @@ These behaviors are intentional and should not be changed:
 | `CORS_ALLOWED_ORIGINS` | `*` | Comma-separated allowed CORS origins |
 | `NIM_PROMPT_CACHE_ENABLED` | `false` | Enable proxy-side prompt cache for NIM |
 | `DRAIN_TIMEOUT_SECS` | `30` | Max graceful drain duration before forced shutdown |
+| `UPSTREAM_FIRST_BYTE_TIMEOUT_SECS` | `60` | First-byte (response-headers) timeout (Issue #83). Aborts a stalled upstream that accepts the connection but never responds, instead of hanging Claude Code indefinitely — `read_timeout` only fires AFTER the first byte. Wraps `send()` in both retry paths; must be > 0 |
 | `TELEMETRY_ENABLED` | `true` | Master switch — set `false` to disable all telemetry |
 | `TELEMETRY_BEACON_URL` | `https://nexus-beacon-receiver.enerby212.workers.dev/v1/beacon` | Beacon endpoint URL. Set to empty string to disable beacon only |
 | `BEACON_AUTH_TOKEN` | (compiled in) | Auth token for beacon endpoint. Override via env var if needed |

--- a/src/proxy/retry.rs
+++ b/src/proxy/retry.rs
@@ -17,6 +17,26 @@ use crate::proxy::overflow_tracker::OverflowLoopTracker;
 pub(crate) fn chunk_timeout_secs() -> u64 {
     std::env::var("CHUNK_TIMEOUT_SECS").ok().and_then(|v| v.parse().ok()).unwrap_or(120)
 }
+
+/// Issue #83 (P0): first-byte (response-headers) timeout.
+///
+/// reqwest's `read_timeout` only fires AFTER the first byte is received, so an upstream
+/// that accepts the TLS connection but never sends a response (model stall, e.g. a dead
+/// or overloaded NIM model) would hang the request forever. We wrap the upstream
+/// `send()` future in this timeout: `send()` resolves once the response headers arrive,
+/// so this bounds time-to-first-byte WITHOUT capping the total stream duration (which is
+/// why CR1/CR2 removed the global `.timeout()` for streaming).
+///
+/// Default 60s — generous enough for a legitimate model cold start, bounded so a stall
+/// can never block Claude Code indefinitely. Configurable via
+/// `UPSTREAM_FIRST_BYTE_TIMEOUT_SECS` (must be > 0; invalid/zero falls back to default).
+pub(crate) fn first_byte_timeout_secs() -> u64 {
+    std::env::var("UPSTREAM_FIRST_BYTE_TIMEOUT_SECS")
+        .ok()
+        .and_then(|v| v.parse().ok())
+        .filter(|&v| v > 0)
+        .unwrap_or(60)
+}
 pub(crate) const MAX_SSE_BUFFER: usize = 10 * 1024 * 1024; // 10MB safety limit for SSE buffer
 
 /// Compute the clamped `max_tokens` for a retry on a clampable (`Fixable`) upstream error.
@@ -135,7 +155,30 @@ pub(crate) async fn resilient_send(
             req_builder = req_builder.header("anthropic-version", version);
         }
 
-        let response = req_builder.send().await?;
+        let response = match tokio::time::timeout(
+            Duration::from_secs(first_byte_timeout_secs()),
+            req_builder.send(),
+        )
+        .await
+        {
+            Ok(send_result) => send_result?,
+            Err(_elapsed) => {
+                // Issue #83 (P0): upstream stalled (no response headers within the first-byte
+                // budget). The 300s builder timeout would still bound this eventually, but fail
+                // fast so a stalled model can't tie up the request for a full 5 minutes.
+                circuit_breaker.record_failure(generation).await;
+                tracing::error!(
+                    "⛔ first-byte timeout: upstream '{}' sent no response within {}s (model stall)",
+                    upstream_name,
+                    first_byte_timeout_secs()
+                );
+                return Err(ProxyError::Upstream(format!(
+                    "Upstream '{}' stalled: no response within {}s (model unavailable)",
+                    upstream_name,
+                    first_byte_timeout_secs()
+                )));
+            }
+        };
         let status = response.status();
 
         if status.is_success() {
@@ -391,7 +434,31 @@ pub(crate) async fn resilient_send_raw(
             req_builder = req_builder.header("anthropic-version", version);
         }
 
-        let response = req_builder.send().await?;
+        let response = match tokio::time::timeout(
+            Duration::from_secs(first_byte_timeout_secs()),
+            req_builder.send(),
+        )
+        .await
+        {
+            Ok(send_result) => send_result?,
+            Err(_elapsed) => {
+                // Issue #83 (P0): the upstream accepted the connection but sent no response
+                // headers within the first-byte budget (model stall). Without this the stream
+                // hangs forever — reqwest's read_timeout only fires AFTER the first byte.
+                // Record a CB failure so a persistently-stalled model trips the breaker.
+                circuit_breaker.record_failure(generation).await;
+                tracing::error!(
+                    "⛔ [stream] first-byte timeout: upstream '{}' sent no response within {}s (model stall)",
+                    upstream_name,
+                    first_byte_timeout_secs()
+                );
+                return Err(ProxyError::Upstream(format!(
+                    "Upstream '{}' stalled: no response within {}s (model unavailable)",
+                    upstream_name,
+                    first_byte_timeout_secs()
+                )));
+            }
+        };
         let status = response.status();
 
         if status.is_success() {
@@ -686,5 +753,37 @@ mod clamp_max_tokens_tests {
             "",
         );
         assert_eq!(got, 1024, "margin must be able to push below MIN_CLAMP_TOKENS to fit");
+    }
+}
+
+#[cfg(test)]
+mod first_byte_timeout_tests {
+    use super::first_byte_timeout_secs;
+
+    /// Save/restore the single env var this test touches so it is order-independent.
+    fn with_env<T>(value: Option<&str>, f: impl FnOnce() -> T) -> T {
+        let key = "UPSTREAM_FIRST_BYTE_TIMEOUT_SECS";
+        let prev = std::env::var(key).ok();
+        match value {
+            Some(v) => std::env::set_var(key, v),
+            None => std::env::remove_var(key),
+        }
+        let out = f();
+        match prev {
+            Some(p) => std::env::set_var(key, p),
+            None => std::env::remove_var(key),
+        }
+        out
+    }
+
+    #[test]
+    fn default_and_overrides() {
+        // Default 60s when unset.
+        assert_eq!(with_env(None, first_byte_timeout_secs), 60);
+        // Honoured when valid.
+        assert_eq!(with_env(Some("30"), first_byte_timeout_secs), 30);
+        // Zero and invalid fall back to the default — a 0s budget would abort every request.
+        assert_eq!(with_env(Some("0"), first_byte_timeout_secs), 60);
+        assert_eq!(with_env(Some("garbage"), first_byte_timeout_secs), 60);
     }
 }


### PR DESCRIPTION
## Summary

Closes #83 (**CRITICAL / P0**). CR1 replaced the global `.timeout(300s)` with `read_timeout(120s)`, but reqwest's `read_timeout` only fires **after the first byte**. When a NIM model accepts the TLS connection but never sends a response (model stall, e.g. `glm-5.1`), the streaming path (`resilient_send_raw`, no total timeout by design) **hangs forever** — blocking every Claude Code session indefinitely.

## Fix

Wrap the upstream `send()` in `tokio::time::timeout(first_byte_timeout_secs, default 60s)` in **both** `resilient_send` and `resilient_send_raw`. `send()` resolves once the response headers arrive, so this bounds **time-to-first-byte** WITHOUT capping the total stream duration (the reason CR1/CR2 removed the global timeout for streaming). On timeout:
- record a circuit-breaker failure (a persistently-stalled model trips the breaker → subsequent requests fail fast),
- return a clear `"Upstream '<name>' stalled: no response within Ns"` error instead of hanging.

Configurable via `UPSTREAM_FIRST_BYTE_TIMEOUT_SECS` (must be > 0).

## Test plan

- [x] `cargo test` — **402 green** (+1: helper default/override/invalid).
- [x] `cargo fmt --check`, `cargo clippy -- -D warnings` — clean.
- [x] **Deterministic stall test**: an upstream that accepts TCP but never responds, with `UPSTREAM_FIRST_BYTE_TIMEOUT_SECS=3` → the streaming request **aborts in 3.91s** with `{"error":{"message":"Upstream 'default' stalled: no response within 3s (model unavailable)"}}` instead of hanging. Server log: `⛔ [stream] first-byte timeout: ... model stall`.
- [x] **Happy-path no-regression**: existing wiremock integration tests exercise both send paths through the new wrapper (upstream responds < budget → transparent).
- [ ] Post-merge re-test on the released build.

## Notes

- The non-streaming path already had `.timeout(300s)` (bounded), but now also fails fast on a first-byte stall for consistency.
- The issue also noted 3 dead models in the prod `.env` config (404/410/stall) — that is an operational config cleanup, separate from this code fix; the upcoming fallback chain (#67) provides the routing-level recovery.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a configurable timeout for waiting on the first response byte from upstream services.
  * Streamed and non-streamed requests now fail faster when an upstream connection stalls before sending headers.
  * Invalid or non-positive timeout settings safely fall back to a default value.

* **Bug Fixes**
  * Improved handling of stalled upstream connections by returning a clearer error when no response headers arrive in time.
  * Retry behavior now respects the first-byte timeout consistently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->