### PR TITLE
fix(retry): add model fallback chain on non-transient failures (#67)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -175,6 +175,7 @@ These behaviors are intentional and should not be changed:
 | `NIM_PROMPT_CACHE_ENABLED` | `false` | Enable proxy-side prompt cache for NIM |
 | `DRAIN_TIMEOUT_SECS` | `30` | Max graceful drain duration before forced shutdown |
 | `UPSTREAM_FIRST_BYTE_TIMEOUT_SECS` | `60` | First-byte (response-headers) timeout (Issue #83). Aborts a stalled upstream that accepts the connection but never responds, instead of hanging Claude Code indefinitely — `read_timeout` only fires AFTER the first byte. Wraps `send()` in both retry paths; must be > 0 |
+| `FALLBACK_MODELS` | (none) | Comma-separated, priority-ordered upstream model ids (Issue #67). When the primary model fails with a non-transient signal — 5xx, model-not-found/EOL (404/410), or a first-byte stall — NEXUS swaps to the next model here (same upstream) instead of giving up, so one dead model can't take down every session mapped to it. Max 2 fallbacks; **not** triggered on 429 (rate limit, retried) or 401/403 (auth) |
 | `TELEMETRY_ENABLED` | `true` | Master switch — set `false` to disable all telemetry |
 | `TELEMETRY_BEACON_URL` | `https://nexus-beacon-receiver.enerby212.workers.dev/v1/beacon` | Beacon endpoint URL. Set to empty string to disable beacon only |
 | `BEACON_AUTH_TOKEN` | (compiled in) | Auth token for beacon endpoint. Override via env var if needed |

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -72,9 +72,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.102"
+version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
 
 [[package]]
 name = "arc-swap"

--- a/src/proxy/retry.rs
+++ b/src/proxy/retry.rs
@@ -37,6 +37,51 @@ pub(crate) fn first_byte_timeout_secs() -> u64 {
         .filter(|&v| v > 0)
         .unwrap_or(60)
 }
+
+/// Issue #67: priority-ordered fallback models (comma-separated upstream model ids in
+/// `FALLBACK_MODELS`). When the primary model fails with a non-transient error
+/// (5xx / model-not-found / EOL / stall — NOT 429 or auth), NEXUS retries the request
+/// against the next model here before giving up, so one dead model cannot take down every
+/// session mapped to it. Empty (default) = no fallback.
+pub(crate) fn fallback_models() -> Vec<String> {
+    std::env::var("FALLBACK_MODELS")
+        .ok()
+        .map(|s| s.split(',').map(|m| m.trim().to_string()).filter(|m| !m.is_empty()).collect())
+        .unwrap_or_default()
+}
+
+/// Max fallback models to try per request (Issue #67: "max 2 fallbacks").
+pub(crate) const MAX_FALLBACKS: usize = 2;
+
+/// Whether an upstream HTTP status is fallback-eligible: a non-transient signal that THIS
+/// model is unavailable and another might work. 429 (rate limit) is Retryable elsewhere;
+/// 401/403 (auth) and 400 (bad request / context overflow) are config/input errors that a
+/// different model cannot fix.
+pub(crate) fn is_fallback_eligible_status(status: u16) -> bool {
+    matches!(status, 500 | 502 | 503 | 504 | 404 | 410)
+}
+
+/// Issue #67: swap `openai_req.model` to the next fallback (within `MAX_FALLBACKS`).
+/// Returns the new model name when a swap happened, or None when fallbacks are exhausted.
+fn try_next_fallback(
+    openai_req: &mut openai::OpenAIRequest,
+    fallback_used: &mut usize,
+) -> Option<String> {
+    if *fallback_used >= MAX_FALLBACKS {
+        return None;
+    }
+    let next = fallback_models().get(*fallback_used)?.clone();
+    *fallback_used += 1;
+    let prev = std::mem::replace(&mut openai_req.model, next.clone());
+    tracing::warn!(
+        "🔀 [fallback] model '{}' failed — falling back to '{}' (fallback {}/{})",
+        prev,
+        next,
+        *fallback_used,
+        MAX_FALLBACKS
+    );
+    Some(next)
+}
 pub(crate) const MAX_SSE_BUFFER: usize = 10 * 1024 * 1024; // 10MB safety limit for SSE buffer
 
 /// Compute the clamped `max_tokens` for a retry on a clampable (`Fixable`) upstream error.
@@ -105,6 +150,7 @@ pub(crate) async fn resilient_send(
     client_headers: &crate::proxy::headers::ClientHeaders,
 ) -> ProxyResult<openai::OpenAIResponse> {
     let mut attempt: u32 = 0;
+    let mut fallback_used: usize = 0; // Issue #67: fallback models tried so far
 
     loop {
         attempt += 1;
@@ -172,6 +218,11 @@ pub(crate) async fn resilient_send(
                     upstream_name,
                     first_byte_timeout_secs()
                 );
+                // Issue #67: a stall means THIS model is unavailable — try a fallback model.
+                if try_next_fallback(openai_req, &mut fallback_used).is_some() {
+                    attempt = 0;
+                    continue;
+                }
                 return Err(ProxyError::Upstream(format!(
                     "Upstream '{}' stalled: no response within {}s (model unavailable)",
                     upstream_name,
@@ -238,6 +289,17 @@ pub(crate) async fn resilient_send(
 
         match class {
             ErrorClass::Retryable { base_delay_ms, max_retries, reason } => {
+                // Issue #67: a 5xx is a model-availability signal. If a fallback model is
+                // configured, switch to it on the first such failure instead of burning the
+                // full (slow, backoff-growing) retry budget on a likely-dead model — CC would
+                // time out first. Falls through to the normal retry/exhaust path when no
+                // fallback is configured or all fallbacks have been used.
+                if is_fallback_eligible_status(status.as_u16())
+                    && try_next_fallback(openai_req, &mut fallback_used).is_some()
+                {
+                    attempt = 0;
+                    continue;
+                }
                 if attempt >= max_retries {
                     // Only record ONE CB failure when ALL retries are exhausted.
                     // Internal retries are self-healing — they must not individually
@@ -364,6 +426,15 @@ pub(crate) async fn resilient_send(
                         crate::str_utils::safe_truncate(&upstream_err.message, 300)
                     )));
                 }
+                // Issue #67: a non-transient failure (5xx / model-not-found / EOL) means THIS
+                // model is unavailable — try a fallback before giving up. Auth (401/403) and
+                // bad-request/overflow (400) are excluded: a different model cannot fix them.
+                if is_fallback_eligible_status(status.as_u16())
+                    && try_next_fallback(openai_req, &mut fallback_used).is_some()
+                {
+                    attempt = 0;
+                    continue;
+                }
                 return Err(ProxyError::Upstream(format!(
                     "Fatal {} ({}): {}",
                     status,
@@ -387,6 +458,7 @@ pub(crate) async fn resilient_send_raw(
     client_headers: &crate::proxy::headers::ClientHeaders,
 ) -> ProxyResult<reqwest::Response> {
     let mut attempt: u32 = 0;
+    let mut fallback_used: usize = 0; // Issue #67: fallback models tried so far
 
     loop {
         attempt += 1;
@@ -452,6 +524,11 @@ pub(crate) async fn resilient_send_raw(
                     upstream_name,
                     first_byte_timeout_secs()
                 );
+                // Issue #67: a stall means THIS model is unavailable — try a fallback model.
+                if try_next_fallback(openai_req, &mut fallback_used).is_some() {
+                    attempt = 0;
+                    continue;
+                }
                 return Err(ProxyError::Upstream(format!(
                     "Upstream '{}' stalled: no response within {}s (model unavailable)",
                     upstream_name,
@@ -487,6 +564,17 @@ pub(crate) async fn resilient_send_raw(
 
         match class {
             ErrorClass::Retryable { base_delay_ms, max_retries, reason } => {
+                // Issue #67: a 5xx is a model-availability signal. If a fallback model is
+                // configured, switch to it on the first such failure instead of burning the
+                // full (slow, backoff-growing) retry budget on a likely-dead model — CC would
+                // time out first. Falls through to the normal retry/exhaust path when no
+                // fallback is configured or all fallbacks have been used.
+                if is_fallback_eligible_status(status.as_u16())
+                    && try_next_fallback(openai_req, &mut fallback_used).is_some()
+                {
+                    attempt = 0;
+                    continue;
+                }
                 if attempt >= max_retries {
                     // Only record ONE CB failure when ALL retries are exhausted.
                     // Internal retries are self-healing — they must not individually
@@ -612,6 +700,15 @@ pub(crate) async fn resilient_send_raw(
                         "Context window full: {}. Use /compact to reduce context.",
                         crate::str_utils::safe_truncate(&upstream_err.message, 300)
                     )));
+                }
+                // Issue #67: a non-transient failure (5xx / model-not-found / EOL) means THIS
+                // model is unavailable — try a fallback before giving up. Auth (401/403) and
+                // bad-request/overflow (400) are excluded: a different model cannot fix them.
+                if is_fallback_eligible_status(status.as_u16())
+                    && try_next_fallback(openai_req, &mut fallback_used).is_some()
+                {
+                    attempt = 0;
+                    continue;
                 }
                 return Err(ProxyError::Upstream(format!(
                     "Fatal {} ({}): {}",
@@ -785,5 +882,86 @@ mod first_byte_timeout_tests {
         // Zero and invalid fall back to the default — a 0s budget would abort every request.
         assert_eq!(with_env(Some("0"), first_byte_timeout_secs), 60);
         assert_eq!(with_env(Some("garbage"), first_byte_timeout_secs), 60);
+    }
+}
+
+#[cfg(test)]
+mod fallback_tests {
+    use super::{fallback_models, is_fallback_eligible_status, try_next_fallback, MAX_FALLBACKS};
+    use crate::models::openai::OpenAIRequest;
+
+    fn with_fallbacks<T>(value: Option<&str>, f: impl FnOnce() -> T) -> T {
+        let key = "FALLBACK_MODELS";
+        let prev = std::env::var(key).ok();
+        match value {
+            Some(v) => std::env::set_var(key, v),
+            None => std::env::remove_var(key),
+        }
+        let out = f();
+        match prev {
+            Some(p) => std::env::set_var(key, p),
+            None => std::env::remove_var(key),
+        }
+        out
+    }
+
+    fn req(model: &str) -> OpenAIRequest {
+        OpenAIRequest {
+            model: model.to_string(),
+            messages: vec![],
+            max_tokens: None,
+            temperature: None,
+            top_p: None,
+            stop: None,
+            stream: None,
+            stream_options: None,
+            tools: None,
+            tool_choice: None,
+            chat_template_kwargs: None,
+            response_format: None,
+        }
+    }
+
+    #[test]
+    fn eligible_status_only_non_transient() {
+        for s in [500, 502, 503, 504, 404, 410] {
+            assert!(is_fallback_eligible_status(s), "{s} should be fallback-eligible");
+        }
+        // 429 (retryable), auth (401/403), bad-request/overflow (400), success (200) must NOT.
+        for s in [200, 400, 401, 403, 429] {
+            assert!(!is_fallback_eligible_status(s), "{s} must NOT be fallback-eligible");
+        }
+    }
+
+    // All FALLBACK_MODELS-dependent assertions run in one test so the process-wide env var is
+    // never mutated concurrently by a sibling test.
+    #[test]
+    fn fallback_parsing_and_swap() {
+        // Default: no fallbacks.
+        assert_eq!(with_fallbacks(None, fallback_models), Vec::<String>::new());
+        // Parse, trim, and drop empty entries.
+        assert_eq!(
+            with_fallbacks(Some("a, b ,, c"), fallback_models),
+            vec!["a".to_string(), "b".to_string(), "c".to_string()]
+        );
+        // Swaps in priority order and stops at MAX_FALLBACKS (2) even if more are configured.
+        with_fallbacks(Some("m1,m2,m3"), || {
+            let mut r = req("primary");
+            let mut used = 0usize;
+            assert_eq!(try_next_fallback(&mut r, &mut used).as_deref(), Some("m1"));
+            assert_eq!(r.model, "m1");
+            assert_eq!(try_next_fallback(&mut r, &mut used).as_deref(), Some("m2"));
+            assert_eq!(r.model, "m2");
+            assert_eq!(MAX_FALLBACKS, 2);
+            assert_eq!(try_next_fallback(&mut r, &mut used), None, "must stop at MAX_FALLBACKS");
+            assert_eq!(r.model, "m2", "model unchanged once fallbacks are exhausted");
+        });
+        // No fallbacks configured -> None, model untouched.
+        with_fallbacks(None, || {
+            let mut r = req("primary");
+            let mut used = 0usize;
+            assert_eq!(try_next_fallback(&mut r, &mut used), None);
+            assert_eq!(r.model, "primary");
+        });
     }
 }

--- a/src/proxy/retry.rs
+++ b/src/proxy/retry.rs
@@ -212,7 +212,6 @@ pub(crate) async fn resilient_send(
                 // Issue #83 (P0): upstream stalled (no response headers within the first-byte
                 // budget). The 300s builder timeout would still bound this eventually, but fail
                 // fast so a stalled model can't tie up the request for a full 5 minutes.
-                circuit_breaker.record_failure(generation).await;
                 tracing::error!(
                     "⛔ first-byte timeout: upstream '{}' sent no response within {}s (model stall)",
                     upstream_name,
@@ -223,6 +222,10 @@ pub(crate) async fn resilient_send(
                     attempt = 0;
                     continue;
                 }
+                // CodeRabbit (#133): charge the breaker only when the whole fallback chain is
+                // exhausted, not once per stalled model — avoids tripping it prematurely when a
+                // single request stalls across multiple models.
+                circuit_breaker.record_failure(generation).await;
                 return Err(ProxyError::Upstream(format!(
                     "Upstream '{}' stalled: no response within {}s (model unavailable)",
                     upstream_name,
@@ -518,7 +521,6 @@ pub(crate) async fn resilient_send_raw(
                 // headers within the first-byte budget (model stall). Without this the stream
                 // hangs forever — reqwest's read_timeout only fires AFTER the first byte.
                 // Record a CB failure so a persistently-stalled model trips the breaker.
-                circuit_breaker.record_failure(generation).await;
                 tracing::error!(
                     "⛔ [stream] first-byte timeout: upstream '{}' sent no response within {}s (model stall)",
                     upstream_name,
@@ -529,6 +531,10 @@ pub(crate) async fn resilient_send_raw(
                     attempt = 0;
                     continue;
                 }
+                // CodeRabbit (#133): charge the breaker only when the whole fallback chain is
+                // exhausted, not once per stalled model — avoids tripping it prematurely when a
+                // single request stalls across multiple models.
+                circuit_breaker.record_failure(generation).await;
                 return Err(ProxyError::Upstream(format!(
                     "Upstream '{}' stalled: no response within {}s (model unavailable)",
                     upstream_name,


### PR DESCRIPTION
## Summary

Closes #67. When a NIM model failed, NEXUS retried the **same** model and then gave up — a dead model meant complete failure for every session mapped to it (the issue documents a **58-minute outage**). There was no logic to route to an alternative model.

## Fix

Priority-ordered fallback chain via `FALLBACK_MODELS` (comma-separated upstream model ids). When the primary returns a **non-transient model-availability signal**, NEXUS swaps `openai_req.model` to the next fallback (same upstream) and retries, up to `MAX_FALLBACKS` (2). Triggers on:

| Signal | Path | Why |
|--------|------|-----|
| 5xx (500/502/503/504) | Retryable branch — **early** | Switch on the FIRST failure instead of burning the slow, backoff-growing retry budget on a likely-dead model (CC times out first) |
| 404 / 410 (model-not-found / EOL) | Fatal branch | Hard "this model is gone" |
| first-byte stall (#83) | timeout branch | A stalled model is unavailable |

**Excluded:** 429 (rate limit — retried, not a model problem) and 401/403 (auth — a different model can't fix it).

Applied symmetrically in `resilient_send` (non-streaming) and `resilient_send_raw` (streaming). Adds `fallback_models()`, `is_fallback_eligible_status()`, `try_next_fallback()` + unit tests.

## Test plan

- [x] `cargo test` — **404 green** (+2: status eligibility, parse/swap/MAX_FALLBACKS).
- [x] `cargo fmt --check`, `cargo clippy -- -D warnings` — clean.
- [x] **Live — Retryable (503) path**: a mock returning 503 for the primary triggers the fallback on the first failure (`🔀 [fallback] model 'dead-primary-model' failed — falling back to 'good-fallback-model' (fallback 1/2)`), in ~0.5s (no slow retry storm).
- [x] **Live — Fatal (404) path, end-to-end with real content**: a bogus primary against real NVIDIA returns 404 → `💀 404` → `🔀 [fallback] → moonshotai/kimi-k2.6` → kimi's real response (`"fallback works"`) is streamed back to the client in 1.78s.
- [ ] Post-merge re-test on the released build.

## Notes

- Fallback changes the **model**, not the upstream — correct for NIM (one endpoint, many models). The issue's "alternative model" semantics.
- Complements #83: a first-byte stall now both fails fast AND falls back to a working model.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic model fallback support when the primary upstream model is unavailable.
  * Requests can now try up to two priority-ordered fallback models from a new environment setting.
  * Fallbacks apply to both streaming and non-streaming requests.

* **Bug Fixes**
  * Improved handling of upstream failures by switching models for eligible errors instead of immediately failing.
  * Added safeguards to avoid fallback on rate limits and authentication errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->